### PR TITLE
Correct GitHub Actions branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   create:
     tags:
   pull_request:


### PR DESCRIPTION
This repository uses a `main` instead of `master` branch, thus this PR updates the GitHub Actions workflow accordingly.