### PR TITLE
Provide profile for local framework updatesite

### DIFF
--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -18,12 +18,13 @@
 	</properties>
 
 	<repositories>
-		<!-- The aggreated Vitruv updatesite to resolve all its dependencies -->
+		<!-- The aggregated Vitruv updatesite to resolve all its dependencies -->
 		<repository>
 			<id>Vitruv</id>
 			<layout>p2</layout>
 			<url>https://vitruv-tools.github.io/updatesite/nightly/</url>
 		</repository>
+		<!-- The specific Vitruv framework updatesite to be potentially overwritten by local builds -->
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>

--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -13,7 +13,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
+		<!-- A local updatesite for the framework can be specified by overwriting these properties. It defaults to the Vitruv updatesite. -->
+		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/</vitruv.framework.url>
 	</properties>
 
 	<repositories>
@@ -97,6 +98,18 @@
 	</build>
 
 	<profiles>
+		<profile>
+			<id>local-framework</id>
+			<activation>
+				<property>
+					<name>vitruv.framework.path</name>
+				</property>
+			</activation>
+			<properties>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+			</properties>
+		</profile>
+		
 		<profile>
 			<id>dsls-generation</id>
 			<activation>

--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -13,11 +13,17 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<!-- A local updatesite for the framework can be specified by overwriting these properties. It defaults to the Vitruv updatesite. -->
-		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/</vitruv.framework.url>
+		<!-- A local updatesite for the framework can be specified by overwriting these properties. It defaults to the nightly Vitruv framework updatesite. -->
+		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
 	</properties>
 
 	<repositories>
+		<!-- The aggreated Vitruv updatesite to resolve all its dependencies -->
+		<repository>
+			<id>Vitruv</id>
+			<layout>p2</layout>
+			<url>https://vitruv-tools.github.io/updatesite/nightly/</url>
+		</repository>
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>


### PR DESCRIPTION
Like in the [CBS applications](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems), this PR adds a profile to define the path to a local framework build from which the updatesite is then used.