### PR TITLE
Remove aggregated updatesite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}
           external_repository: vitruv-tools/updatesite
           destination_dir: release/framework/${{ steps.releaseVersion.outputs.tag }}
-          publish_dir: releng/tools.vitruv.updatesite.aggregated/target/final
+          publish_dir: releng/tools.vitruv.dsls.updatesite/target/repository
           publish_branch: master
 

--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -113,7 +113,7 @@
 				</property>
 			</activation>
 			<properties>
-				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite/target/repository</vitruv.framework.url>
 			</properties>
 		</profile>
 		


### PR DESCRIPTION
This PR removes the aggregated updatesite generation from the build, as it is built for the complete Vitruv project in the [updatesite](https://github.com/vitruv-tools/updatesite) repository upon deploying new artifact versions.