### PR TITLE
Remove outdated dependency to framework util project

### DIFF
--- a/bundles/tools.vitruv.extensions.dslsruntime.reactions/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.extensions.dslsruntime.reactions/META-INF/MANIFEST.MF
@@ -16,7 +16,6 @@ Require-Bundle: org.apache.log4j;visibility:=reexport,
  tools.vitruv.framework.correspondence;visibility:=reexport,
  tools.vitruv.framework.change;visibility:=reexport,
  tools.vitruv.framework.propagation;visibility:=reexport,
- tools.vitruv.framework.util;visibility:=reexport,
  tools.vitruv.framework.userinteraction;visibility:=reexport,
  edu.kit.ipd.sdq.commons.util.emf
 Bundle-ActivationPolicy: lazy

--- a/features/tools.vitruv.extensions.dslsruntime.feature/feature.xml
+++ b/features/tools.vitruv.extensions.dslsruntime.feature/feature.xml
@@ -29,7 +29,6 @@
       <import plugin="tools.vitruv.framework.change"/>
       <import plugin="tools.vitruv.framework.propagation"/>
       <import plugin="tools.vitruv.framework.domains"/>
-      <import plugin="tools.vitruv.framework.util"/>
       <import plugin="tools.vitruv.framework.userinteraction"/>
       <import plugin="org.eclipse.emf.ecore.xmi"/>
       <import plugin="edu.kit.ipd.sdq.commons.util.java"/>

--- a/releng/tools.vitruv.dsls.dependencywrapper/META-INF/MANIFEST.MF
+++ b/releng/tools.vitruv.dsls.dependencywrapper/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Require-Bundle: tools.vitruv.framework.domains,
  tools.vitruv.framework.change,
  tools.vitruv.framework.change.echange,
  tools.vitruv.framework.propagation,
- tools.vitruv.framework.util,
  edu.kit.ipd.sdq.metamodels.families,
  edu.kit.ipd.sdq.metamodels.insurance,
  edu.kit.ipd.sdq.metamodels.persons


### PR DESCRIPTION
This PR removes dependencies to the `tools.vitruv.framework.util` project, which have accidentally not been removed in #21.