### PR TITLE
Remove aggregated Vitruv updatesite and updatesite versions from build

### DIFF
--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -18,12 +18,6 @@
 	</properties>
 
 	<repositories>
-		<!-- The aggregated Vitruv updatesite to resolve all its dependencies -->
-		<repository>
-			<id>Vitruv</id>
-			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/</url>
-		</repository>
 		<!-- The specific Vitruv framework updatesite to be potentially overwritten by local builds -->
 		<repository>
 			<id>Vitruv Framework</id>

--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -38,12 +38,12 @@
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/2.0.0/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/</url>
 		</repository>
 		<repository>
 			<id>XAnnotations</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/xannotations/1.5.0/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
The aggregated Vitruv updatesite was referenced in the build to resolve the dependencies of the Vitruv projects. This is error prone, because, e.g., when removing a bundle in this project it can still be resolved in the aggregated updatesite, thus leading to a successful build although it should actually fail. Since the transitive dependencies provided by the aggreated Vitruv updatesite have been referenced anyway, we can simply remove the aggregated updatesite reference from the build specification.

In addition, this PR removes the explicit version in the updatesite URLs for the SDQ Commons and XAnnotations dependencies to ensure that always the latest available version is used.