### PR TITLE
Remove domains

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -11,13 +11,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: dsls
-      - name: Checkout CBS Domains
-        uses: actions/checkout@v3
-        with:
-          path: cbsdomains
-          repository: vitruv-tools/Vitruv-Domains-ComponentBasedSystems
-          ref: master
-          fetch-depth: 0
       - name: Checkout CBS Applications
         uses: actions/checkout@v3
         with:
@@ -27,9 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout Matching Applications Branches
         run: |
-          cd cbsdomains
-          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
-          cd ../cbsapplications
+          cd cbsapplications
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
       - name: Cache
         uses: actions/cache@v3
@@ -57,19 +48,6 @@ jobs:
             -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
         env: 
           MAVEN_OPTS: -Djansi.force=true
-      - name: Build Domains
-        working-directory: ./cbsdomains
-        run: >
-            ./mvnw -B -U clean verify
-            -Dstyle.color=always
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
       - name: Build Applications
         uses: GabrielBB/xvfb-action@v1
         with:
@@ -77,7 +55,6 @@ jobs:
           run: >
             ./mvnw -B -U clean verify
             -Dvitruv.dsls.path=${GITHUB_WORKSPACE}/dsls
-            -Dvitruv.domains.path=${GITHUB_WORKSPACE}/cbsdomains
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/bundles/tools.vitruv.applications.demo.familiespersons/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.demo.familiespersons.families2persons,
  tools.vitruv.applications.demo.familiespersons.persons2families
 Require-Bundle: tools.vitruv.extensions.dslsruntime.reactions;visibility:=reexport,
- edu.kit.ipd.sdq.metamodels.families;bundle-version="1.6.1",
- edu.kit.ipd.sdq.metamodels.persons;bundle-version="1.6.1",
+ edu.kit.ipd.sdq.metamodels.families,
+ edu.kit.ipd.sdq.metamodels.persons,
  edu.kit.ipd.sdq.activextendannotations
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.demo.insurancepersons.insurance2persons,
  tools.vitruv.applications.demo.insurancepersons.persons2insurance
 Require-Bundle: tools.vitruv.extensions.dslsruntime.reactions;visibility:=reexport,
- edu.kit.ipd.sdq.metamodels.persons;bundle-version="1.6.1",
- edu.kit.ipd.sdq.metamodels.insurance;bundle-version="1.6.1",
+ edu.kit.ipd.sdq.metamodels.persons,
+ edu.kit.ipd.sdq.metamodels.insurance,
  edu.kit.ipd.sdq.activextendannotations
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/features/tools.vitruv.applications.demo.familiespersons.feature/feature.xml
+++ b/features/tools.vitruv.applications.demo.familiespersons.feature/feature.xml
@@ -20,9 +20,10 @@
    </license>
 
    <requires>
-      <import plugin="tools.vitruv.framework.applications"/>
       <import plugin="tools.vitruv.extensions.dslsruntime.reactions"/>
-      <import plugin="tools.vitruv.domains.demo"/>
+      <import plugin="edu.kit.ipd.sdq.metamodels.families"/>
+      <import plugin="edu.kit.ipd.sdq.metamodels.persons"/>
+      <import plugin="edu.kit.ipd.sdq.activextendannotations"/>
    </requires>
 
    <plugin

--- a/features/tools.vitruv.applications.demo.insurancepersons.feature/feature.xml
+++ b/features/tools.vitruv.applications.demo.insurancepersons.feature/feature.xml
@@ -20,9 +20,10 @@
    </license>
 
    <requires>
-      <import plugin="tools.vitruv.framework.applications"/>
       <import plugin="tools.vitruv.extensions.dslsruntime.reactions"/>
-      <import plugin="tools.vitruv.domains.demo"/>
+      <import plugin="edu.kit.ipd.sdq.metamodels.persons"/>
+      <import plugin="edu.kit.ipd.sdq.metamodels.insurance"/>
+      <import plugin="edu.kit.ipd.sdq.activextendannotations"/>
    </requires>
 
    <plugin

--- a/features/tools.vitruv.dsls.feature/feature.xml
+++ b/features/tools.vitruv.dsls.feature/feature.xml
@@ -20,20 +20,19 @@
    </license>
 
    <requires>
-      <import plugin="org.eclipse.xtend.lib"/>
       <import plugin="org.eclipse.xtext"/>
+      <import plugin="org.eclipse.xtext.xbase"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="org.eclipse.emf.ecore"/>
       <import plugin="edu.kit.ipd.sdq.activextendannotations"/>
+      <import plugin="org.eclipse.xtend.lib"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.xtext.ui"/>
       <import plugin="org.eclipse.pde.ui"/>
       <import plugin="org.eclipse.ui.ide"/>
       <import plugin="org.eclipse.xtext.common.types"/>
-      <import plugin="tools.vitruv.framework.domains"/>
       <import plugin="tools.vitruv.extensions.dslsruntime.mappings"/>
-      <import plugin="org.eclipse.xtext.xbase"/>
-      <import plugin="org.antlr.runtime"/>
       <import plugin="org.eclipse.xtext.xtext.generator"/>
-      <import plugin="org.eclipse.emf.ecore"/>
       <import plugin="org.eclipse.xtext.xbase.lib" version="2.14.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.xtext.util"/>
       <import plugin="org.eclipse.emf.common"/>
@@ -50,11 +49,13 @@
       <import plugin="org.eclipse.ui.editors"/>
       <import plugin="org.eclipse.ui"/>
       <import plugin="org.eclipse.jdt.debug.ui"/>
-      <import plugin="com.google.inject"/>
       <import plugin="tools.vitruv.extensions.dslsruntime.reactions"/>
       <import plugin="tools.vitruv.extensions.dslsruntime.commonalities"/>
-      <import plugin="org.eclipse.core.runtime"/>
       <import plugin="org.eclipse.emf.codegen.ecore"/>
+      <import plugin="com.google.inject"/>
+      <import plugin="edu.kit.ipd.sdq.commons.util.eclipse"/>
+      <import plugin="org.eclipse.emf.mwe.core"/>
+      <import plugin="edu.kit.ipd.sdq.commons.util.java"/>
    </requires>
 
    <plugin

--- a/features/tools.vitruv.extensions.dslsruntime.feature/feature.xml
+++ b/features/tools.vitruv.extensions.dslsruntime.feature/feature.xml
@@ -28,10 +28,11 @@
       <import plugin="tools.vitruv.change.correspondence"/>
       <import plugin="tools.vitruv.change.composite"/>
       <import plugin="tools.vitruv.change.propagation"/>
-      <import plugin="tools.vitruv.framework.domains"/>
       <import plugin="tools.vitruv.change.interaction"/>
       <import plugin="org.eclipse.emf.ecore.xmi"/>
       <import plugin="edu.kit.ipd.sdq.commons.util.java"/>
+      <import plugin="edu.kit.ipd.sdq.activextendannotations"/>
+      <import plugin="edu.kit.ipd.sdq.commons.util.emf"/>
    </requires>
 
    <plugin

--- a/releng/tools.vitruv.dsls.dependencywrapper/META-INF/MANIFEST.MF
+++ b/releng/tools.vitruv.dsls.dependencywrapper/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: tools.vitruv.dsls.dependencywrapper
 Bundle-SymbolicName: tools.vitruv.dsls.dependencywrapper
 Automatic-Module-Name: tools.vitruv.dsls.dependencywrapper
 Bundle-Version: 2.1.0.qualifier
-Require-Bundle: tools.vitruv.framework.domains,
- tools.vitruv.change.composite,
+Require-Bundle: tools.vitruv.change.composite,
  tools.vitruv.change.atomic,
  tools.vitruv.change.propagation,
  edu.kit.ipd.sdq.metamodels.families,


### PR DESCRIPTION
This PR adapts to the removal of domains in the framework. It replaces the dependencies to domains with dependencies to the metamodels and removes the now unnecessary build of the domain project from the GitHub Actions workflow.