### PR TITLE
Specify project encoding explicit to UTF-8 for all projects

### DIFF
--- a/bundles/tools.vitruv.applications.demo.familiespersons/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.common.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.common.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.common/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.common/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.commonalities.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.commonalities.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.commonalities.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.commonalities.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.commonalities/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.commonalities/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.mappings.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.mappings.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.mappings.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.mappings.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.mappings/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.mappings/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.reactions.ide/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.reactions.ide/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.reactions.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.reactions.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.dsls.reactions/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.dsls.reactions/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.extensions.dslsruntime.commonalities.operators/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.extensions.dslsruntime.commonalities.operators/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.extensions.dslsruntime.commonalities/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.extensions.dslsruntime.commonalities/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.extensions.dslsruntime.mappings/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.extensions.dslsruntime.mappings/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/tools.vitruv.extensions.dslsruntime.reactions/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/tools.vitruv.extensions.dslsruntime.reactions/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.applications.demo.familiespersons.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.applications.demo.familiespersons.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.applications.demo.insurancepersons.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.applications.demo.insurancepersons.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.dsls.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.dsls.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/tools.vitruv.extensions.dslsruntime.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/tools.vitruv.extensions.dslsruntime.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/tools.vitruv.dsls.dependencywrapper/.settings/org.eclipse.core.resources.prefs
+++ b/releng/tools.vitruv.dsls.dependencywrapper/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/tools.vitruv.dsls.updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/releng/tools.vitruv.dsls.updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/tools.vitruv.dsls.workflow/.settings/org.eclipse.core.resources.prefs
+++ b/releng/tools.vitruv.dsls.workflow/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.applications.demo.familiespersons.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.applications.demo.familiespersons.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.applications.demo.insurancepersons.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.applications.demo.insurancepersons.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.commonalities.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.commonalities.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.mappings.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.mappings.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.mappings.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.mappings.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.reactions.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.reactions.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/tools.vitruv.dsls.reactions.ui.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/tools.vitruv.dsls.reactions.ui.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
As of Eclipse 06/22 a warning is generated if no explicit project encoding is specified ([source](https://www.eclipse.org/eclipse/news/4.24/platform.php#no-explicit-encoding-project-warning)).
This PR sets the default encoding for all projects to UTF-8.