### PR TITLE
Remove usage of compound Reactions triggers

### DIFF
--- a/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
@@ -15,7 +15,7 @@ execute actions in persons
 
 //========== FAMILY-REGISTER ==========
 //Creation of a {@link PersonRegister} after a {@link FamilyRegister} was created.
-reaction CreatedFamilyRegister {
+reaction InsertedFamilyRegister {
 	after element families::FamilyRegister inserted as root
 	call createPersonRegister(newValue)
 }

--- a/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/persons2families/PersonsToFamilies.reactions
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/persons2families/PersonsToFamilies.reactions
@@ -26,7 +26,7 @@ execute actions in families
 // Creation/ deletion of a registers
 // =================================
 
-reaction CreatedPersonRegister {
+reaction InsertedPersonRegister {
 	after element persons::PersonRegister inserted as root
 	call createFamilyRegister(newValue)
 }

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/insurance2persons/InsuranceToPersons.reactions
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/insurance2persons/InsuranceToPersons.reactions
@@ -11,7 +11,7 @@ reactions: insuranceToPersons
 in reaction to changes in insurance
 execute actions in persons
 
-reaction CreatedInsuranceDatabase {
+reaction InsertedInsuranceDatabase {
 	after element insurance::InsuranceDatabase inserted as root
 	call createPersonRegister(newValue)
 }
@@ -39,7 +39,7 @@ routine deletePersonRegister(insurance::InsuranceDatabase insuranceDatabase) {
 	}
 }
 	
-reaction CreatedClient {
+reaction InsertedClient {
 	after element insurance::InsuranceClient inserted in insurance::InsuranceDatabase[insuranceclient]
 	call createPerson(newValue)
 }

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/persons2insurance/PersonsToInsurance.reactions
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/persons2insurance/PersonsToInsurance.reactions
@@ -11,7 +11,7 @@ reactions: personsToInsurance
 in reaction to changes in persons
 execute actions in insurance
 
-reaction CreatedPersonRegister {
+reaction InsertedPersonRegister {
 	after element persons::PersonRegister inserted as root
 	call createInsuranceDatabase(newValue)
 }
@@ -40,7 +40,7 @@ routine deleteInsuranceDatabase(persons::PersonRegister personsRegister) {
 	}
 }
 
-reaction CreatedPerson {
+reaction InsertedPerson {
 	after element persons::Person inserted in persons::PersonRegister[persons]
 	call createInsuranceClient(newValue)
 }

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
@@ -12,9 +12,9 @@ in reaction to changes in minimal
 execute actions in minimal
 
 /*
- * Creates the model for comparing the further test model with.
+ * Inserts the model for comparing the further test model with.
  */
-reaction CreateRootTest {
+reaction InsertRootTest {
 	after element minimal::Root inserted as root
 	call createRoot(newValue)
 }
@@ -35,7 +35,7 @@ routine createRoot(minimal::Root rootElement) {
 	}
 }
 
-reaction DeleteRootTest {
+reaction RemoveRootTest {
 	after element minimal::Root removed as root
 	call deleteRoot(oldValue)
 }
@@ -116,9 +116,9 @@ routine replaceIdentifiedId(minimal::Identified identified, String value) {
 }
 
 /*
- * CreateNonRootEObjectInList
+ * InsertNonRootEObjectInList
  */
-reaction CreatedNonRootEObjectInList {
+reaction InsertedNonRootEObjectInList {
 	after element minimal::NonRoot inserted in minimal::Root[multiValuedContainmentEReference]
 	call insertNonRoot(affectedEObject, newValue)
 }
@@ -143,9 +143,9 @@ routine insertNonRoot(minimal::Root rootElement, minimal::NonRoot insertedNonRoo
 }
 
 /*
- * DeleteNonRootEObjectInList
+ * RemoveNonRootEObjectInList
  */
-reaction DeletedNonRootEObjectInList {
+reaction RemovedNonRootEObjectInList {
 	after element minimal::NonRoot removed from minimal::Root[multiValuedContainmentEReference]
 	call removeNonRoot(oldValue)
 }


### PR DESCRIPTION
Removes compound change triggers from all application tests in preparation to removing compound triggers from the language at all. The rationale behind this in discussed in #32.

There are only two supported compound triggers: `created and inserted in <container>` and `deleted and removed from <container>`. Those were refactored as follows:
- `created and inserted` was changed to `inserted` for all occurrences
- `deleted and removed` was changed to `removed` for all occurrences

The modifications to the families / persons / insurance demo applications will affect the behaviour for moving elements. Before, no reaction was triggered. Now, the `inserted` reaction will trigger and for some CPRs create the expected element even if it already exists. However, as moving elements is currently not tested, this changed behaviour has no effect on the test results. 
I think the changes are sufficient in their current form and the change to untested semantic is acceptable. If we want to support move operations in the future, this functionality can be added with some future PR.