### PR TITLE
Preparation for renaming all Vitruv default branches to `main`

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           path: cbsapplications
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
-          ref: master
+          ref: main
           fetch-depth: 0
       - name: Checkout Matching Applications Branches
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vitruv DSLs
 [![GitHub Action CI](https://github.com/vitruv-tools/Vitruv-DSLs/workflows/CI/badge.svg)](https://github.com/vitruv-tools/Vitruv-DSLs/actions?query=workflow%3ACI)
 [![Issues](https://img.shields.io/github/issues/vitruv-tools/Vitruv-DSLs.svg)](https://github.com/vitruv-tools/Vitruv-DSLs/issues)
-[![License](https://img.shields.io/github/license/vitruv-tools/Vitruv-DSLs.svg)](https://raw.githubusercontent.com/vitruv-tools/Vitruv-DSLs/master/LICENSE)
+[![License](https://img.shields.io/github/license/vitruv-tools/Vitruv-DSLs.svg)](https://raw.githubusercontent.com/vitruv-tools/Vitruv-DSLs/main/LICENSE)
 
 Vitruv is a framework for view-based software development. It assumes different models to be used for describing a software system,
 which are automatically kept consistent by the framework and its applications. For general information on Vitruv, see our [Wiki](http://vitruv.tools).


### PR DESCRIPTION
Adapts the GitHub actions to renaming the Application-CBS repository's default branch to `main`.

⚠️ Depends on [Vitruv-Applications-CBS#211](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/211)