### PR TITLE
Fix Reactions formatter

### DIFF
--- a/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
@@ -1,7 +1,6 @@
 import static tools.vitruv.applications.demo.familiespersons.families2persons.FamiliesToPersonsHelper.assertFemale
 import static tools.vitruv.applications.demo.familiespersons.families2persons.FamiliesToPersonsHelper.assertMale
 import static tools.vitruv.applications.demo.familiespersons.families2persons.FamiliesToPersonsHelper.assertValidFirstname
-
 import static extension tools.vitruv.applications.demo.familiespersons.families2persons.FamiliesToPersonsHelper.getPersonName
 import static extension edu.kit.ipd.sdq.metamodels.families.FamiliesUtil.getMembers
 import static extension edu.kit.ipd.sdq.metamodels.families.FamiliesUtil.getRegister
@@ -19,20 +18,23 @@ reaction InsertedFamilyRegister {
 	after element families::FamilyRegister inserted as root
 	call createPersonRegister(newValue)
 }
+
 routine createPersonRegister(families::FamilyRegister familyRegister) {
 	create {
-		val personRegister = new persons::PersonRegister	
+		val personRegister = new persons::PersonRegister
 	}
 	update {
 		persistProjectRelative(familyRegister, personRegister, "model/persons.persons")
 		addCorrespondenceBetween(personRegister, familyRegister)
 	}
 }
+
 //Deletion of a {@link PersonRegister} after a {@link FamilyRegister} was deleted.
 reaction DeletedFamilyRegister {
 	after element families::FamilyRegister deleted
 	call deletePersonRegister(affectedEObject)
 }
+
 routine deletePersonRegister(families::FamilyRegister familyRegister) {
 	match {
 		val personRegister = retrieve persons::PersonRegister corresponding to familyRegister
@@ -43,12 +45,12 @@ routine deletePersonRegister(families::FamilyRegister familyRegister) {
 	}
 }
 
-
 //========== FAMILY ==========
 reaction DeletedFamily {
 	after element families::Family deleted
 	call affectedEObject.members.forEach[deletePerson()]
 }
+
 //Lastname of {@link Family} changed.
 reaction ChangedLastName {
 	after attribute replaced at families::Family[lastName]
@@ -57,7 +59,7 @@ reaction ChangedLastName {
 
 reaction CreatedFather {
 	after element families::Member replaced at families::Family[father]
-		with newValue !== null
+	with newValue !== null
 	call {
 		updateNameAndCorrespondencesAfterMemberBecameFather(newValue, affectedEObject)
 		createMaleFromNewMember(newValue, affectedEObject)
@@ -66,7 +68,7 @@ reaction CreatedFather {
 
 reaction CreatedMother {
 	after element families::Member replaced at families::Family[mother]
-		with newValue !== null
+	with newValue !== null
 	call {
 		updateNameAndCorrespondencesAfterMemberBecameMother(newValue, affectedEObject)
 		createFemaleFromNewMember(newValue, affectedEObject)
@@ -77,8 +79,8 @@ reaction CreatedMother {
 reaction InsertedSon {
 	after element families::Member inserted in families::Family[sons]
 	call {
-	    createOrFindMale(newValue, affectedEObject)
-	    existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(newValue, affectedEObject)
+		createOrFindMale(newValue, affectedEObject)
+		existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(newValue, affectedEObject)
 	}
 }
 
@@ -86,18 +88,18 @@ reaction InsertedSon {
 reaction InsertedDaughter {
 	after element families::Member inserted in families::Family[daughters]
 	call {
-	    createOrFindFemale(newValue, affectedEObject)
-	    existingMemberBecameDaughter_updateNameAndCorrespondencesOfCorrespondingFemale(newValue, affectedEObject)
+		createOrFindFemale(newValue, affectedEObject)
+		existingMemberBecameDaughter_updateNameAndCorrespondencesOfCorrespondingFemale(newValue, affectedEObject)
 	}
 }
 
 routine createOrFindMale(families::Member newMember, families::Family family) {
-    match {
-        require absence of persons::Male corresponding to newMember
-    }
-    update {
-        createMale(newMember, family)
-    }
+	match {
+		require absence of persons::Male corresponding to newMember
+	}
+	update {
+		createMale(newMember, family)
+	}
 }
 
 //Checks whether the newFather was actually just created (has no corresponding person) or not.
@@ -114,14 +116,17 @@ routine createMaleFromNewMember(families::Member newFather, families::Family fam
 //Creates corresponding male person for fathers, sons, sets up correspondences
 routine createMale(families::Member newMember, families::Family family) {
 	match {
-		check { assertValidFirstname(newMember) true }
+		check {
+			assertValidFirstname(newMember)
+			true
+		}
 		val personsRegister = retrieve persons::PersonRegister corresponding to family.register
 	}
 	create {
 		val person = new persons::Male
 	}
 	update {
- 		person.fullName = newMember.getPersonName
+		person.fullName = newMember.getPersonName
 		personsRegister.persons += person
 		addCorrespondenceBetween(newMember, person)
 		addCorrespondenceBetween(family, person)
@@ -129,12 +134,12 @@ routine createMale(families::Member newMember, families::Family family) {
 }
 
 routine createOrFindFemale(families::Member newMember, families::Family family) {
-    match {
-        require absence of persons::Female corresponding to newMember
-    }
-    update {
-        createFemale(newMember, family)
-    }
+	match {
+		require absence of persons::Female corresponding to newMember
+	}
+	update {
+		createFemale(newMember, family)
+	}
 }
 
 //Checks whether the newMother was actually just created (has no corresponding person) or not.
@@ -151,14 +156,17 @@ routine createFemaleFromNewMember(families::Member newMother, families::Family f
 //Creates corresponding female person for mothers and daughters and sets up correspondences
 routine createFemale(families::Member newMember, families::Family family) {
 	match {
-		check { assertValidFirstname(newMember) true }
+		check {
+			assertValidFirstname(newMember)
+			true
+		}
 		val personsRegister = retrieve persons::PersonRegister corresponding to family.register
 	}
 	create {
 		val person = new persons::Female
 	}
 	update {
- 		person.fullName = newMember.getPersonName
+		person.fullName = newMember.getPersonName
 		personsRegister.persons += person
 		addCorrespondenceBetween(newMember, person)
 		addCorrespondenceBetween(family, person)
@@ -170,8 +178,10 @@ routine createFemale(families::Member newMember, families::Family family) {
 // newFamily is the family in which the newFather is from now on the father
 routine updateNameAndCorrespondencesAfterMemberBecameFather(families::Member newFather, families::Family newFamily) {
 	match {
-		val correspondingPerson = retrieve persons::Person corresponding to newFather
-		with { assertMale(correspondingPerson) true }
+		val correspondingPerson = retrieve persons::Person corresponding to newFather with {
+			assertMale(correspondingPerson)
+			true
+		}
 	}
 	update {
 		updateNameAndCorrespondencesOfCorrespondingPerson(newFather, newFamily)
@@ -183,8 +193,10 @@ routine updateNameAndCorrespondencesAfterMemberBecameFather(families::Member new
 // newFamily is the family in which the newMother is from now on the mother
 routine updateNameAndCorrespondencesAfterMemberBecameMother(families::Member newMother, families::Family newFamily) {
 	match {
-		val correspondingPerson = retrieve persons::Person corresponding to newMother
-		with { assertFemale(correspondingPerson) true }
+		val correspondingPerson = retrieve persons::Person corresponding to newMother with {
+			assertFemale(correspondingPerson)
+			true
+		}
 	}
 	update {
 		updateNameAndCorrespondencesOfCorrespondingPerson(newMother, newFamily)
@@ -211,8 +223,10 @@ routine updateNameAndCorrespondencesOfCorrespondingPerson(families::Member newMe
 //First check if insertedChild is actually male which it has to be in order to become a son.
 routine existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(families::Member insertedChild, families::Family newFamily) {
 	match {
-		val correspondingPerson = retrieve persons::Person corresponding to insertedChild
-		with { assertMale(correspondingPerson) true }
+		val correspondingPerson = retrieve persons::Person corresponding to insertedChild with {
+			assertMale(correspondingPerson)
+			true
+		}
 	}
 	update {
 		updatePersonFamilyCorrespondence(insertedChild, newFamily)
@@ -222,8 +236,10 @@ routine existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(
 //First check if insertedChild is actually female which it has to be in order to become a daughter.
 routine existingMemberBecameDaughter_updateNameAndCorrespondencesOfCorrespondingFemale(families::Member insertedChild, families::Family newFamily) {
 	match {
-		val correspondingPerson = retrieve persons::Person corresponding to insertedChild
-		with { assertFemale(correspondingPerson) true }
+		val correspondingPerson = retrieve persons::Person corresponding to insertedChild with {
+			assertFemale(correspondingPerson)
+			true
+		}
 	}
 	update {
 		updatePersonFamilyCorrespondence(insertedChild, newFamily)
@@ -234,7 +250,7 @@ routine existingMemberBecameDaughter_updateNameAndCorrespondencesOfCorresponding
 //correspondingPerson gets a new name (since most likely the lastname changed) and correspondences are updated.
 //newFamily is the family in which the insertedChild is now contained.
 //oldFamily is the family in which the insertedChild was a member before.
-routine updatePersonFamilyCorrespondence (families::Member insertedChild, families::Family newFamily) {
+routine updatePersonFamilyCorrespondence(families::Member insertedChild, families::Family newFamily) {
 	match {
 		val correspondingPerson = retrieve persons::Person corresponding to insertedChild
 		val oldFamily = retrieve families::Family corresponding to correspondingPerson
@@ -257,7 +273,10 @@ reaction ChangedFirstName {
 //Check if the new name is allowed and then update the name of the corresponding person.
 routine updatePersonName(families::Member member) {
 	match {
-		check { assertValidFirstname(member) true }
+		check {
+			assertValidFirstname(member)
+			true
+		}
 		val person = retrieve persons::Person corresponding to member
 	}
 	update {

--- a/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/persons2families/PersonsToFamilies.reactions
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/persons2families/PersonsToFamilies.reactions
@@ -2,14 +2,12 @@ import edu.kit.ipd.sdq.metamodels.families.Family
 import edu.kit.ipd.sdq.metamodels.persons.Female
 import edu.kit.ipd.sdq.metamodels.persons.Male
 import tools.vitruv.applications.demo.familiespersons.persons2families.FamilyRole
-
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.askUserWhetherPersonIsParentOrChild
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.askUserWhetherPersonIsParentOrChildDuringRenaming
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.askUserWhichFamilyToInsertTheMemberIn
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.assertValidFullname
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.noParent
 import static tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.sameLastname
-
 import static extension tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getFirstname
 import static extension tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getLastname
 import static extension tools.vitruv.applications.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getRegister
@@ -25,7 +23,6 @@ execute actions in families
 // =================================
 // Creation/ deletion of a registers
 // =================================
-
 reaction InsertedPersonRegister {
 	after element persons::PersonRegister inserted as root
 	call createFamilyRegister(newValue)
@@ -40,7 +37,6 @@ routine createFamilyRegister(persons::PersonRegister createdPersonRegister) {
 		addCorrespondenceBetween(newFamilyRegister, createdPersonRegister)
 	}
 }
-
 
 reaction DeletedPersonRegister {
 	after element persons::PersonRegister deleted
@@ -60,7 +56,6 @@ routine deleteFamilyRegister(persons::PersonRegister deletedPersonsRegister) {
 // ========================
 // New creation of a member
 // ========================
-
 reaction InsertedPerson {
 	after element persons::Person inserted in persons::PersonRegister[persons]
 	call insertAsParentOrChild(newValue)
@@ -68,7 +63,10 @@ reaction InsertedPerson {
 
 routine insertAsParentOrChild(persons::Person insertedPerson) {
 	match {
-		check { assertValidFullname(insertedPerson) true}
+		check {
+			assertValidFullname(insertedPerson)
+			true
+		}
 	}
 	update {
 		val FamilyRole role = askUserWhetherPersonIsParentOrChild(userInteractor, insertedPerson)
@@ -85,12 +83,13 @@ routine createChild(persons::Person insertedPerson) {
 	}
 	update {
 		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(insertedPerson))
-		val Family familyToInsertInto = if (matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(userInteractor, insertedPerson, matchingFamilies)
-	    if (familyToInsertInto === null) {
-	        createChildInNewFamily(insertedPerson)
-	    } else {
-	        createChildInExistingFamily(insertedPerson, familyToInsertInto)
-	    }
+		val Family familyToInsertInto = if(matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(
+				userInteractor, insertedPerson, matchingFamilies)
+		if (familyToInsertInto === null) {
+			createChildInNewFamily(insertedPerson)
+		} else {
+			createChildInExistingFamily(insertedPerson, familyToInsertInto)
+		}
 	}
 }
 
@@ -99,8 +98,10 @@ routine createParent(persons::Person insertedPerson) {
 		val familiesRegister = retrieve families::FamilyRegister corresponding to insertedPerson.register
 	}
 	update {
-		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(insertedPerson)).filter(noParent(insertedPerson))
-		val Family familyToInsertInto = if (matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(userInteractor, insertedPerson, matchingFamilies)
+		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(insertedPerson)).filter(
+			noParent(insertedPerson))
+		val Family familyToInsertInto = if(matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(
+				userInteractor, insertedPerson, matchingFamilies)
 		if (familyToInsertInto === null) {
 			createParentInNewFamily(insertedPerson)
 		} else {
@@ -170,18 +171,21 @@ routine createParentInExistingFamily(persons::Person insertedPerson, families::F
 // ==============================================================
 // Inserting existing member into different family after renaming
 // ==============================================================
-
 reaction ChangedFullName {
 	after attribute replaced at persons::Person[fullName]
-		with oldValue !== null && !oldValue.equals(newValue)
+	with oldValue !== null && !oldValue.equals(newValue)
 	call changeNames(affectedEObject, oldValue)
 }
+
 /* Apply firstname changes to the corresponding {@link Member}
  * Apply lastname changes to the corresponding {@link Family}
  */
 routine changeNames(persons::Person renamedPerson, String oldFullname) {
 	match {
-		check { assertValidFullname(renamedPerson) true}
+		check {
+			assertValidFullname(renamedPerson)
+			true
+		}
 		val oldFamily = retrieve families::Family corresponding to renamedPerson
 		val correspondingMember = retrieve families::Member corresponding to renamedPerson
 	}
@@ -199,12 +203,14 @@ routine reactToLastnameAndFamilyRoleChanges(persons::Person renamedPerson, Strin
 		val correspondingMember = retrieve families::Member corresponding to renamedPerson
 	}
 	update {
-		val boolean wasChildBeforeRenaming = correspondingMember.familySon === oldFamily || correspondingMember.familyDaughter === oldFamily
-		val boolean isSupposedToBeAChild = askUserWhetherPersonIsParentOrChildDuringRenaming(userInteractor, oldFullname, renamedPerson.fullName, wasChildBeforeRenaming) == FamilyRole.Child
+		val boolean wasChildBeforeRenaming = correspondingMember.familySon === oldFamily ||
+			correspondingMember.familyDaughter === oldFamily
+		val boolean isSupposedToBeAChild = askUserWhetherPersonIsParentOrChildDuringRenaming(userInteractor,
+			oldFullname, renamedPerson.fullName, wasChildBeforeRenaming) == FamilyRole.Child
 
 		// If neither the lastname, nor the role of the member inside the family changed,
 		// then only the firstname changed and nothing else must be done.
-		if ((wasChildBeforeRenaming !== isSupposedToBeAChild) || (oldFamily.lastName != renamedPerson.lastname)){
+		if ((wasChildBeforeRenaming !== isSupposedToBeAChild) || (oldFamily.lastName != renamedPerson.lastname)) {
 			if (oldFamily.members.size == 1) {
 				// If the member is alone in its family just rename the oldFamily
 				// and maybe adjust the role of the member which is no problem
@@ -243,8 +249,10 @@ routine insertExistingMemberIntoUserChosenFamilyAsParent(persons::Person renamed
 		val correspondingMember = retrieve families::Member corresponding to renamedPerson
 	}
 	update {
-		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(renamedPerson)).filter(noParent(renamedPerson))
-		val Family chosenFamily = if (matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(userInteractor, renamedPerson, matchingFamilies)
+		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(renamedPerson)).filter(
+			noParent(renamedPerson))
+		val Family chosenFamily = if(matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(
+				userInteractor, renamedPerson, matchingFamilies)
 		if (chosenFamily === null) {
 			insertExistingMemberIntoNewFamilyAsParent(renamedPerson)
 		} else {
@@ -260,7 +268,8 @@ routine insertExistingMemberIntoUserChosenFamilyAsChild(persons::Person renamedP
 	}
 	update {
 		val Iterable<Family> matchingFamilies = familiesRegister.families.filter(sameLastname(renamedPerson))
-		val Family chosenFamily = if (matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(userInteractor, renamedPerson, matchingFamilies)
+		val Family chosenFamily = if(matchingFamilies.empty) null else askUserWhichFamilyToInsertTheMemberIn(
+				userInteractor, renamedPerson, matchingFamilies)
 		if (chosenFamily === null) {
 			insertExistingMemberIntoNewFamilyAsChild(renamedPerson)
 		} else {
@@ -311,7 +320,7 @@ routine insertExistingMemberIntoExistingFamilyAsParent(persons::Person renamedPe
 		}
 		removeCorrespondenceBetween(renamedPerson, oldFamily)
 		addCorrespondenceBetween(renamedPerson, familyToInsertInto)
-		//correspondence between renamedPerson and correspondingMember does already exist
+	// correspondence between renamedPerson and correspondingMember does already exist
 	}
 }
 
@@ -327,14 +336,13 @@ routine insertExistingMemberIntoExistingFamilyAsChild(persons::Person renamedPer
 		}
 		removeCorrespondenceBetween(renamedPerson, oldFamily)
 		addCorrespondenceBetween(renamedPerson, familyToInsertInto)
-		//correspondence between renamedPerson and correspondingMember does already exist
+	// correspondence between renamedPerson and correspondingMember does already exist
 	}
 }
 
 //=================================================================================
 // Deletion of a person and therefore of corresponding member and maybe also family
 //=================================================================================
-
 reaction DeletePerson {
 	after element persons::Person deleted
 	call deleteMember(affectedEObject)

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/insurance2persons/InsuranceToPersons.reactions
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/insurance2persons/InsuranceToPersons.reactions
@@ -1,7 +1,6 @@
 import edu.kit.ipd.sdq.metamodels.insurance.Gender
 import edu.kit.ipd.sdq.metamodels.persons.Male
 import edu.kit.ipd.sdq.metamodels.persons.Female
-
 import static extension edu.kit.ipd.sdq.metamodels.insurance.InsuranceUtil.getInsuranceDatabase
 
 import "edu.kit.ipd.sdq.metamodels.persons" as persons
@@ -40,7 +39,7 @@ routine deletePersonRegister(insurance::InsuranceDatabase insuranceDatabase) {
 		removeCorrespondenceBetween(personRegister, insuranceDatabase)
 	}
 }
-	
+
 reaction InsertedClient {
 	after element insurance::InsuranceClient inserted in insurance::InsuranceDatabase[insuranceclient]
 	call createPerson(newValue)
@@ -49,9 +48,9 @@ reaction InsertedClient {
 routine createPerson(insurance::InsuranceClient client) {
 	update {
 		switch client.gender {
-			case Gender.MALE : createMalePerson(client)
-			case Gender.FEMALE : createFemalePerson(client)
-			default : throw new IllegalArgumentException("Unknown gender for persons")
+			case Gender.MALE: createMalePerson(client)
+			case Gender.FEMALE: createFemalePerson(client)
+			default: throw new IllegalArgumentException("Unknown gender for persons")
 		}
 	}
 }
@@ -109,17 +108,18 @@ routine changeGender(insurance::InsuranceClient client) {
 	}
 	update {
 		switch client.gender {
-			case Gender.MALE :
+			case Gender.MALE:
 				if (!(person instanceof Male)) {
 					deletePerson(client)
 					createMalePerson(client)
 				}
-			case Gender.FEMALE :
+			case Gender.FEMALE:
 				if (!(person instanceof Female)) {
 					deletePerson(client)
 					createFemalePerson(client)
 				}
-			default : throw new IllegalArgumentException("Gender of client is unknown.")
+			default:
+				throw new IllegalArgumentException("Gender of client is unknown.")
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/persons2insurance/PersonsToInsurance.reactions
+++ b/bundles/tools.vitruv.applications.demo.insurancepersons/src/tools/vitruv/applications/demo/insurancepersons/persons2insurance/PersonsToInsurance.reactions
@@ -1,7 +1,6 @@
 import edu.kit.ipd.sdq.metamodels.insurance.Gender
 import edu.kit.ipd.sdq.metamodels.persons.Male
 import edu.kit.ipd.sdq.metamodels.persons.Female
-
 import static extension edu.kit.ipd.sdq.metamodels.persons.PersonsUtil.getPersonRegister
 
 import "edu.kit.ipd.sdq.metamodels.persons" as persons
@@ -26,7 +25,7 @@ routine createInsuranceDatabase(persons::PersonRegister personRegister) {
 	}
 }
 
-reaction DeletedPersonRegister{
+reaction DeletedPersonRegister {
 	after element persons::PersonRegister deleted
 	call deleteInsuranceDatabase(affectedEObject)
 }
@@ -56,9 +55,9 @@ routine createInsuranceClient(persons::Person person) {
 	update {
 		newClient.name = person.fullName
 		switch person {
-			Male : newClient.gender = Gender.MALE
-			Female : newClient.gender = Gender.FEMALE
-			default : throw new IllegalArgumentException("Gender of client is unknown.")
+			Male: newClient.gender = Gender.MALE
+			Female: newClient.gender = Gender.FEMALE
+			default: throw new IllegalArgumentException("Gender of client is unknown.")
 		}
 		insuranceDatabase.insuranceclient += newClient
 		addCorrespondenceBetween(person, newClient)

--- a/bundles/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
+++ b/bundles/tools.vitruv.dsls.reactions.ui/src/tools/vitruv/dsls/reactions/ui/outline/ReactionsLanguageOutlineTreeProvider.xtend
@@ -15,13 +15,13 @@ import tools.vitruv.dsls.reactions.language.toplevelelements.Reaction
 import static extension tools.vitruv.dsls.reactions.util.ReactionsLanguageUtil.*
 import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineInput
 import tools.vitruv.dsls.reactions.language.toplevelelements.ReactionsImport
-import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineCallBlock
 import tools.vitruv.dsls.reactions.language.ModelElementChange
 import tools.vitruv.dsls.reactions.language.ModelAttributeChange
 import tools.vitruv.dsls.reactions.language.ArbitraryModelChange
 import tools.vitruv.dsls.reactions.language.toplevelelements.UpdateBlock
 import tools.vitruv.dsls.reactions.language.toplevelelements.CreateBlock
 import tools.vitruv.dsls.reactions.language.toplevelelements.MatchBlock
+import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineCall
 
 /**
  * Outline structure definition for a reactions file.
@@ -117,7 +117,7 @@ class ReactionsLanguageOutlineTreeProvider extends DefaultOutlineTreeProvider {
 		return true;
 	}
 
-	protected def boolean _isLeaf(RoutineCallBlock element) {
+	protected def boolean _isLeaf(RoutineCall element) {
 		return true;
 	}
 

--- a/bundles/tools.vitruv.dsls.reactions/model/TopLevelElements.ecore
+++ b/bundles/tools.vitruv.dsls.reactions/model/TopLevelElements.ecore
@@ -37,13 +37,13 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="trigger" eType="#//Trigger"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="callRoutine" eType="#//RoutineCallBlock"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="callRoutine" eType="#//RoutineCall"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="reactionsSegment" lowerBound="1"
         eType="#//ReactionsSegment" eOpposite="#//ReactionsSegment/reactions"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Trigger">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="precondition" eType="#//PreconditionCodeBlock"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="precondition" eType="ecore:EClass ../../org.eclipse.xtext.xbase/model/Xbase.ecore#//XExpression"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Routine">
@@ -84,17 +84,15 @@
         eType="ecore:EClass ../../tools.vitruv.dsls.common/model/CommonLanguageElements.ecore#//NamedMetaclassReference"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="CodeBlock">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="code" eType="ecore:EClass ../../org.eclipse.xtext.xbase/model/Xbase.ecore#//XExpression"
-        containment="true"/>
-  </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="PreconditionCodeBlock" eSuperTypes="#//CodeBlock"/>
   <eClassifiers xsi:type="ecore:EClass" name="NamedJavaElementReference">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass ../../org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmTypeReference"
         containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="RoutineCallBlock" eSuperTypes="#//CodeBlock"/>
-  <eClassifiers xsi:type="ecore:EClass" name="ReactionRoutineCall" eSuperTypes="#//RoutineCallBlock"/>
-  <eClassifiers xsi:type="ecore:EClass" name="UpdateBlock" eSuperTypes="#//CodeBlock"/>
+  <eClassifiers xsi:type="ecore:EClass" name="RoutineCall" eSuperTypes="#//CodeExecutionBlock"/>
+  <eClassifiers xsi:type="ecore:EClass" name="UpdateBlock" eSuperTypes="#//CodeExecutionBlock"/>
+  <eClassifiers xsi:type="ecore:EClass" name="CodeExecutionBlock">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="code" eType="ecore:EClass ../../org.eclipse.xtext.xbase/model/Xbase.ecore#//XExpression"
+        containment="true"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -44,11 +44,8 @@ ReactionRoutineCall returns toplevelelements::RoutineCallBlock:
 // *********** TRIGGER ***********
 
 Trigger returns toplevelelements::Trigger:
-	'after' ModelChange
+	'after' (ArbitraryModelChange | ConcreteModelChange)
 	('with' precondition=PreconditionCodeBlock)?;
-
-ModelChange:
-	ArbitraryModelChange | ConcreteModelChange;
 
 ConcreteModelChange:
 	ModelElementChange | ModelAttributeChange;

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -2,7 +2,6 @@ grammar tools.vitruv.dsls.reactions.ReactionsLanguage with org.eclipse.xtext.xba
 hidden(WS, SL_COMMENT)
 
 generate language "http://vitruv.tools/dsls/reactions/language"
-
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 import "http://vitruv.tools/dsls/common/elements" as common
 import "http://vitruv.tools/dsls/reactions/language/toplevelelements" as toplevelelements
@@ -17,55 +16,55 @@ MetamodelImport returns common::MetamodelImport:
 
 ReactionsSegment returns toplevelelements::ReactionsSegment:
 	'reactions:' name=ValidID
-	'in' 'reaction' 'to' 'changes' 'in' fromMetamodels+=[common::MetamodelImport] ('and' fromMetamodels+=[common::MetamodelImport])*
+	'in' 'reaction' 'to' 'changes' 'in' fromMetamodels+=[common::MetamodelImport] ('and'
+	fromMetamodels+=[common::MetamodelImport])*
 	'execute' 'actions' 'in' toMetamodels+=[common::MetamodelImport] ('and' toMetamodels+=[common::MetamodelImport])*
 	(reactionsImports+=ReactionsImport)*
 	(reactions+=Reaction |
-		routines+=Routine)*;
+	routines+=Routine)*;
 
 ReactionsImport returns toplevelelements::ReactionsImport:
-	'import' (routinesOnly?='routines')? importedReactionsSegment=[toplevelelements::ReactionsSegment] (useQualifiedNames?='using' 'qualified' 'names')?;
+	'import' (routinesOnly?='routines')? importedReactionsSegment=[toplevelelements::ReactionsSegment]
+	(useQualifiedNames?='using' 'qualified' 'names')?;
 
 // *********************************
 // *********** REACTIONS ***********
 // *********************************
-
 Reaction returns toplevelelements::Reaction:
 	(documentation=ML_COMMENT)?
 	'reaction' (overriddenReactionsSegment=[toplevelelements::ReactionsSegment] '::')? name=ValidID '{'
-		trigger=Trigger
-		callRoutine=ReactionRoutineCall
+	trigger=Trigger
+	callRoutine=RoutineCall
 	'}';
-	
-ReactionRoutineCall returns toplevelelements::RoutineCallBlock:
-	{toplevelelements::RoutineCallBlock}
-	'call' CodeBlock;
+
+RoutineCall returns toplevelelements::RoutineCall:
+	{toplevelelements::RoutineCall}
+	'call' code=XExpression;
 
 // *********** TRIGGER ***********
-
 Trigger returns toplevelelements::Trigger:
-	'after' (ArbitraryModelChange | ConcreteModelChange)
-	('with' precondition=PreconditionCodeBlock)?;
+	'after' (ArbitraryModelChange | ConcreteModelChange);
 
 ConcreteModelChange:
 	ModelElementChange | ModelAttributeChange;
 
 ModelElementChange:
 	{ModelElementChange}
-	'element' (elementType=UnnamedMetaclassReference)? changeType=ElementChangeType;
+	'element' (elementType=UnnamedMetaclassReference)? changeType=ElementChangeType
+	('with' precondition=XExpression)?;
 
 ModelAttributeChange:
 	'attribute' ({ModelAttributeInsertedChange} 'inserted' 'in' |
-		{ModelAttributeRemovedChange} 'removed' 'from' |
-		{ModelAttributeReplacedChange} 'replaced' 'at')
-		feature=MetaclassEAttributeReference;
+	{ModelAttributeRemovedChange} 'removed' 'from' |
+	{ModelAttributeReplacedChange} 'replaced' 'at')
+	feature=MetaclassEAttributeReference
+	('with' precondition=XExpression)?;
 
 ArbitraryModelChange:
-	{ArbitraryModelChange} 'anychange';
-
+	{ArbitraryModelChange} 'anychange'
+	('with' precondition=XExpression)?;
 
 // *********** Atomic element changes ***********
-
 ElementExistenceChangeType returns ElementExistenceChangeType:
 	ElementCreationChangeType | ElementDeletionChangeType;
 
@@ -96,10 +95,10 @@ ElementInsertionAsRootChangeType:
 
 ElementRemovalChangeType:
 	(ElementRemovalAsRootChangeType | ElementRemovalFromListChangeType);
-	
+
 ElementRemovalAsRootChangeType:
 	{ElementRemovalAsRootChangeType} 'removed' 'as' 'root';
-		
+
 ElementRemovalFromListChangeType:
 	'removed' 'from' ElementReferenceChangeType;
 
@@ -112,46 +111,48 @@ ElementChangeType returns ElementChangeType:
 // ***************************************
 // *********** REPAIR ROUTINES ***********
 // ***************************************
-
 Routine returns toplevelelements::Routine:
 	(documentation=ML_COMMENT)?
 	'routine' (overrideImportPath=RoutineOverrideImportPath '::')? name=ValidID input=RoutineInput '{'
-		matchBlock=MatchBlock?
-		createBlock=CreateBlock?
-		updateBlock=UpdateBlock?
+	matchBlock=MatchBlock?
+	createBlock=CreateBlock?
+	updateBlock=UpdateBlock?
 	'}';
 
 RoutineOverrideImportPath returns toplevelelements::RoutineOverrideImportPath:
-	reactionsSegment=[toplevelelements::ReactionsSegment] ({toplevelelements::RoutineOverrideImportPath.parent=current} '.' reactionsSegment=[toplevelelements::ReactionsSegment])*;
+	reactionsSegment=[toplevelelements::ReactionsSegment] ({toplevelelements::RoutineOverrideImportPath.parent=current}
+	'.' reactionsSegment=[toplevelelements::ReactionsSegment])*;
 
 RoutineInput returns toplevelelements::RoutineInput:
 	{toplevelelements::RoutineInput}
 	'(' ((modelInputElements+=NamedMetaclassReference | "plain" javaInputElements+=NamedJavaElementReference)
-		(',' (modelInputElements+=NamedMetaclassReference | "plain" javaInputElements+=NamedJavaElementReference))*)? ')';
+	(',' (modelInputElements+=NamedMetaclassReference | "plain" javaInputElements+=NamedJavaElementReference))*)? ')';
 
 // *********** MATCH ***********
-
 MatchBlock returns toplevelelements::MatchBlock:
 	{toplevelelements::MatchBlock}
 	'match' '{'
-		(matchStatements+=MatchStatement)+
+	(matchStatements+=MatchStatement)+
 	'}';
 
 MatchStatement returns toplevelelements::MatchStatement:
 	RetrieveOrRequireAbscenceOfModelElement | MatchCheckStatement;
 
 RetrieveOrRequireAbscenceOfModelElement:
-	(RequireAbscenceOfModelElement | RetrieveModelElement) elementType=UnnamedMetaclassReference 
-	'corresponding' 'to' correspondenceSource=CorrespondingObjectCodeBlock ('tagged' 'with' Taggable)? 
-	('with' precondition=PreconditionCodeBlock)?; 
+	(RequireAbscenceOfModelElement | RetrieveModelElement);
 
 RequireAbscenceOfModelElement returns RequireAbscenceOfModelElement:
 	{RequireAbscenceOfModelElement}
-	'require' 'absence' 'of';
-	
+	'require' 'absence' 'of' elementType=UnnamedMetaclassReference
+	'corresponding' 'to' correspondenceSource=XExpression ('tagged' tag=XExpression)?
+	('with' precondition=XExpression)?;
+
 RetrieveModelElement:
 	{RetrieveModelElement}
-	('val' name=ValidID '=')? 'retrieve' retrievalType=RetrieveModelElementTypeStatement;
+	('val' name=ValidID '=')?
+	'retrieve' retrievalType=RetrieveModelElementTypeStatement elementType=UnnamedMetaclassReference
+	'corresponding' 'to' correspondenceSource=XExpression ('tagged' tag=XExpression)?
+	('with' precondition=XExpression)?;
 
 RetrieveModelElementTypeStatement returns RetrieveModelElementType:
 	{RetrieveOneModelElement} (optional?='optional' | asserted?='asserted')? |
@@ -159,43 +160,23 @@ RetrieveModelElementTypeStatement returns RetrieveModelElementType:
 
 MatchCheckStatement:
 	{MatchCheckStatement}
-	'check' (asserted?='asserted')? CodeBlock;
-	
-// *********** CREATE ***********
+	'check' (asserted?='asserted')? condition=XExpression;
 
+// *********** CREATE ***********
 CreateBlock returns toplevelelements::CreateBlock:
 	{toplevelelements::CreateBlock}
 	'create' '{'
-		createStatements+=CreateStatement*
+	createStatements+=CreateStatement*
 	'}';
-	
+
 CreateStatement returns common::NamedMetaclassReference:
 	'val' name=ValidID '=' 'new' MetaclassReference;
 
 // *********** UPDATE ***********
 UpdateBlock returns toplevelelements::UpdateBlock:
-	'update' CodeBlock;
+	'update' code=XExpression;
 
 // ****** CODE BLOCKS ******
-
-fragment CodeBlock returns toplevelelements::CodeBlock:
-	code=XExpression;
-
-fragment Taggable:
-	tag=TagCodeBlock;
-
-TagCodeBlock returns TagCodeBlock:
-	{TagCodeBlock}
-	CodeBlock;
-
-PreconditionCodeBlock returns toplevelelements::PreconditionCodeBlock:
-	{toplevelelements::PreconditionCodeBlock}
-	CodeBlock;
-
-CorrespondingObjectCodeBlock returns CorrespondingObjectCodeBlock:
-	{CorrespondingObjectCodeBlock}
-	CodeBlock;
-
 fragment MetaclassReference returns common::MetaclassReference:
 	(metamodel=[common::MetamodelImport] '::')? metaclass=[ecore::EClass|QualifiedName];
 
@@ -213,4 +194,3 @@ MetaclassEAttributeReference returns common::MetaclassEAttributeReference:
 
 MetaclassEReferenceReference returns common::MetaclassEReferenceReference:
 	MetaclassReference '[' feature=[ecore::EReference|ValidID] ']';
-

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionBuilder.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionBuilder.xtend
@@ -22,7 +22,7 @@ import tools.vitruv.dsls.reactions.language.toplevelelements.TopLevelElementsFac
 import static com.google.common.base.Preconditions.*
 import tools.vitruv.dsls.common.elements.ElementsFactory
 import tools.vitruv.dsls.reactions.language.LanguageFactory
-import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineCallBlock
+import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineCall
 
 class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 
@@ -247,7 +247,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 
 		def private addRoutineCall(FluentRoutineBuilder routineBuilder, RoutineCallParameter... parameters) {
 			if (reaction.callRoutine === null) {
-				reaction.callRoutine = TopLevelElementsFactory.eINSTANCE.createRoutineCallBlock => [
+				reaction.callRoutine = TopLevelElementsFactory.eINSTANCE.createRoutineCall => [
 					code = routineCall(routineBuilder, parameters)
 				]
 			} else {
@@ -276,7 +276,7 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 				routineInitializer)
 		}
 
-		def private routineCall(RoutineCallBlock routineCall, FluentRoutineBuilder routineBuilder,
+		def private routineCall(RoutineCall routineCall, FluentRoutineBuilder routineBuilder,
 			RoutineCallParameter... parameters) {
 			(XbaseFactory.eINSTANCE.createXFeatureCall => [
 				explicitOperationCall = true
@@ -313,10 +313,8 @@ class FluentReactionBuilder extends FluentReactionsSegmentChildBuilder {
 		}
 
 		def with(Function<TypeProvider, XExpression> expressionProvider) {
-			reaction.trigger.precondition = TopLevelElementsFactory.eINSTANCE.createPreconditionCodeBlock => [
-				code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
-					expressions += extractExpressions(expressionProvider.apply(typeProvider))
-				]
+			reaction.trigger.precondition = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
+				expressions += extractExpressions(expressionProvider.apply(typeProvider))
 			]
 			return new RoutineCallBuilder(builder)
 		}

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentRoutineBuilder.xtend
@@ -15,7 +15,6 @@ import tools.vitruv.dsls.reactions.language.RetrieveModelElement
 import tools.vitruv.dsls.reactions.language.RetrieveOrRequireAbscenceOfModelElement
 import tools.vitruv.dsls.reactions.language.toplevelelements.Routine
 import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineOverrideImportPath
-import tools.vitruv.dsls.reactions.language.Taggable
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*
@@ -319,12 +318,12 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 
 		def correspondingTo(String element) {
 			statement.correspondenceSource = correspondingElement(element)
-			new TaggedWithBuilder(builder, statement)
+			new RetrieveModelElementMatchBlockStatementTagBuilder(builder, statement)
 		}
 
 		def correspondingTo(Function<TypeProvider, XExpression> expressionBuilder) {
 			statement.correspondenceSource = correspondingElement(expressionBuilder)
-			new TaggedWithBuilder(builder, statement)
+			new RetrieveModelElementMatchBlockStatementTagBuilder(builder, statement)
 		}
 	}
 
@@ -340,19 +339,19 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 		def affectedEObject() {
 			requireAffectedEObject = true
 			statement.correspondenceSource = correspondingElement(CHANGE_AFFECTED_ELEMENT_ATTRIBUTE)
-			new TaggedWithBuilder(builder, statement)
+			new RetrieveModelElementMatchBlockStatementTagBuilder(builder, statement)
 		}
 
 		def newValue() {
 			requireNewValue = true
 			statement.correspondenceSource = correspondingElement(CHANGE_NEW_VALUE_ATTRIBUTE)
-			new TaggedWithBuilder(builder, statement)
+			new RetrieveModelElementMatchBlockStatementTagBuilder(builder, statement)
 		}
 
 		def oldValue() {
 			requireOldValue = true
 			statement.correspondenceSource = correspondingElement(CHANGE_OLD_VALUE_ATTRIBUTE)
-			new TaggedWithBuilder(builder, statement)
+			new RetrieveModelElementMatchBlockStatementTagBuilder(builder, statement)
 		}
 	}
 
@@ -381,7 +380,7 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 
 		def check(Function<TypeProvider, XExpression> expressionBuilder) {
 			val statement = LanguageFactory.eINSTANCE.createMatchCheckStatement => [
-				code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
+				condition = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
 					expressions += extractExpressions(expressionBuilder.apply(typeProvider))
 				]
 			]
@@ -395,34 +394,28 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 		}
 	}
 
-	static class TaggedWithBuilder {
+	static class RetrieveModelElementMatchBlockStatementTagBuilder {
 		val extension FluentRoutineBuilder builder
-		val Taggable taggable
+		val RetrieveOrRequireAbscenceOfModelElement statement
 
-		private new(FluentRoutineBuilder builder, Taggable taggable) {
+		private new(FluentRoutineBuilder builder, RetrieveOrRequireAbscenceOfModelElement statement) {
 			this.builder = builder
-			this.taggable = taggable
+			this.statement = statement
 		}
 		
 		def void taggedWithAnything() {
-			taggable.tag = LanguageFactory.eINSTANCE.createTagCodeBlock => [
-				code = XbaseFactory.eINSTANCE.createXNullLiteral
-			]
+			statement.tag = XbaseFactory.eINSTANCE.createXNullLiteral
 		}
 
 		def void taggedWith(String tag) {
-			taggable.tag = LanguageFactory.eINSTANCE.createTagCodeBlock => [
-				code = XbaseFactory.eINSTANCE.createXStringLiteral => [
-					value = tag
-				]
+			statement.tag = XbaseFactory.eINSTANCE.createXStringLiteral => [
+				value = tag
 			]
 		}
 
 		def void taggedWith(Function<TypeProvider, XExpression> tagExpressionBuilder) {
-			taggable.tag = LanguageFactory.eINSTANCE.createTagCodeBlock => [
-				code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
-					expressions += extractExpressions(tagExpressionBuilder.apply(typeProvider))
-				]
+			statement.tag = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
+				expressions += extractExpressions(tagExpressionBuilder.apply(typeProvider))
 			]
 		}
 	}
@@ -750,18 +743,14 @@ class FluentRoutineBuilder extends FluentReactionsSegmentChildBuilder {
 	}
 
 	def private correspondingElement(String name) {
-		LanguageFactory.eINSTANCE.createCorrespondingObjectCodeBlock => [
-			code = XbaseFactory.eINSTANCE.createXFeatureCall.whenJvmTypes [
-				feature = correspondingMethodParameter(name)
-			]
+		XbaseFactory.eINSTANCE.createXFeatureCall.whenJvmTypes [
+			feature = correspondingMethodParameter(name)
 		]
 	}
 
 	def private correspondingElement(Function<TypeProvider, XExpression> expressionBuilder) {
-		LanguageFactory.eINSTANCE.createCorrespondingObjectCodeBlock => [
-			code = XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
-				expressions += extractExpressions(expressionBuilder.apply(typeProvider))
-			]
+		XbaseFactory.eINSTANCE.createXBlockExpression.whenJvmTypes [
+			expressions += extractExpressions(expressionBuilder.apply(typeProvider))
 		]
 	}
 

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -156,12 +156,12 @@ class ReactionClassGenerator extends ClassGenerator {
 		if (!hasUserDefinedPrecondition) {
 			return null
 		}
-		val preconditionBlock = reaction.trigger.precondition
+		val precondition = reaction.trigger.precondition
 		val methodName = USER_DEFINED_PRECONDITION_METHOD_NAME
-		return preconditionBlock.toMethod(methodName, typeRef(Boolean.TYPE)) [
+		return reaction.trigger.toMethod(methodName, typeRef(Boolean.TYPE)) [
 			visibility = JvmVisibility.PRIVATE
 			parameters += generateAccessibleElementsParameters(changeType.generatePropertiesParameterList)
-			body = preconditionBlock.code
+			body = precondition
 		]
 	}
 

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
@@ -5,7 +5,6 @@ import tools.vitruv.dsls.reactions.codegen.typesbuilder.TypesBuilderExtensionPro
 import org.eclipse.xtext.common.types.JvmGenericType
 import org.eclipse.xtext.common.types.JvmVisibility
 import org.eclipse.xtext.common.types.JvmOperation
-import tools.vitruv.dsls.reactions.language.Taggable
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 import tools.vitruv.dsls.reactions.language.RetrieveOrRequireAbscenceOfModelElement
 import tools.vitruv.dsls.reactions.language.RetrieveModelElement
@@ -240,14 +239,14 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 			«tagString»'''
 	}
 
-	private def JvmOperation generateMethodGetRetrieveTag(Taggable taggable,
+	private def JvmOperation generateMethodGetRetrieveTag(RetrieveOrRequireAbscenceOfModelElement elementRetrieve,
 		Iterable<AccessibleElement> currentlyAccessibleElements) {
-		val methodName = "getRetrieveTag" + counterGetRetrieveTagMethods++;
+		val methodName = "getRetrieveTag" + counterGetRetrieveTagMethods++
 
-		return taggable.tag?.generateAndAddMethod(methodName, typeRef(String)) [
+		return elementRetrieve.generateAndAddMethod(methodName, typeRef(String)) [
 			parameters += generateAccessibleElementsParameters(currentlyAccessibleElements)
-			body = taggable.tag.code;
-		];
+			body = elementRetrieve.tag
+		]
 	}
 
 	private def generateMethodCorrespondencePrecondition(RetrieveOrRequireAbscenceOfModelElement elementRetrieve,
@@ -258,20 +257,19 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 			val element = new AccessibleElement(name ?: RETRIEVAL_PRECONDITION_METHOD_TARGET, elementRetrieve.elementType.javaClassName)
 			parameters += generateParameters(currentlyAccessibleElements)
 			parameters += generateParameter(element)
-			body = elementRetrieve.precondition.code
-		];
+			body = elementRetrieve.precondition
+		]
 	}
 
 	private def generateMethodGetCorrespondenceSource(RetrieveOrRequireAbscenceOfModelElement elementRetrieve,
 		Iterable<AccessibleElement> currentlyAccessibleElements) {
 		val methodName = "getCorrepondenceSource" +
-			(elementRetrieve.retrieveOrRequireAbscenceMethodSuffix ?: counterGetCorrespondenceSource++);
+			(elementRetrieve.retrieveOrRequireAbscenceMethodSuffix ?: counterGetCorrespondenceSource++)
 
-		val correspondenceSourceBlock = elementRetrieve.correspondenceSource
-		return correspondenceSourceBlock?.generateAndAddMethod(methodName, typeRef(EObject)) [
+		return elementRetrieve?.generateAndAddMethod(methodName, typeRef(EObject)) [
 			parameters += generateAccessibleElementsParameters(currentlyAccessibleElements)
-			body = correspondenceSourceBlock.code;
-		];
+			body = elementRetrieve.correspondenceSource
+		]
 	}
 
 	private def String getUserExecutionMethodCallString(JvmOperation method) '''
@@ -279,11 +277,11 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 
 	private def JvmOperation generateMethodMatcherPrecondition(MatchCheckStatement checkStatement,
 		Iterable<AccessibleElement> currentlyAccessibleElements) {
-		val methodName = "checkMatcherPrecondition" + counterCheckMatcherPreconditionMethods++;
+		val methodName = "checkMatcherPrecondition" + counterCheckMatcherPreconditionMethods++
 		return checkStatement.generateAndAddMethod(methodName, typeRef(Boolean.TYPE)) [
 			parameters += generateAccessibleElementsParameters(currentlyAccessibleElements)
-			body = checkStatement.code;
-		];
+			body = checkStatement.condition
+		]
 	}
 
 	private def dispatch getRetrieveOrRequireAbscenceMethodSuffix(RetrieveOrRequireAbscenceOfModelElement statement) {
@@ -299,7 +297,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	}
 
 	private def generateMethodParameterCallList(JvmOperation method) {
-		return method.parameters.generateMethodParameterCallList;
+		return method.parameters.generateMethodParameterCallList
 	}
 
 	private def generateMethodParameterCallList(Iterable<JvmFormalParameter> parameters) '''

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
@@ -9,8 +9,8 @@ import org.eclipse.xtext.common.types.JvmGenericType
 import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Preconditions.checkNotNull
 import org.eclipse.xtend2.lib.StringConcatenationClient
-import tools.vitruv.dsls.reactions.language.toplevelelements.CodeBlock
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
+import tools.vitruv.dsls.reactions.language.toplevelelements.CodeExecutionBlock
 
 /**
  * Generates for an {@link UpdateBlock} of a routine a class with a method (with the name defined in 
@@ -22,7 +22,7 @@ class UpdateBlockClassGenerator extends StepExecutionClassGenerator {
 	static val ROUTINES_FACADE_CLASS_PARAMETER_NAME = "_routinesFacade"
 
 	val String qualifiedClassName
-	val CodeBlock updateBlock
+	val CodeExecutionBlock updateBlock
 	val JvmTypeReference routinesFacadeClassReference
 	val Iterable<AccessibleElement> accessibleElements
 
@@ -39,7 +39,7 @@ class UpdateBlockClassGenerator extends StepExecutionClassGenerator {
 	 * @param routinesFacadeClassReference a type reference to the facade class for calling other routines
 	 * @param accessibleElements the elements to be passed to the generated {@code match} method, must not be {@code null}
 	 */
-	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, String qualifiedClassName, CodeBlock updateBlock,
+	new(TypesBuilderExtensionProvider typesBuilderExtensionProvider, String qualifiedClassName, CodeExecutionBlock updateBlock,
 		JvmTypeReference routinesFacadeClassReference, Iterable<AccessibleElement> accessibleElements) {
 		super(typesBuilderExtensionProvider)
 		checkArgument(!qualifiedClassName.nullOrEmpty, "class name must not be null or empty")

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
@@ -2,14 +2,6 @@ package tools.vitruv.dsls.reactions.formatting2
 
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.xtext.formatting2.IFormattableDocument
-import org.eclipse.xtext.xbase.XAssignment
-import org.eclipse.xtext.xbase.XBlockExpression
-import org.eclipse.xtext.xbase.XConstructorCall
-import org.eclipse.xtext.xbase.XExpression
-import org.eclipse.xtext.xbase.XFeatureCall
-import org.eclipse.xtext.xbase.XListLiteral
-import org.eclipse.xtext.xbase.XMemberFeatureCall
-import org.eclipse.xtext.xbase.XVariableDeclaration
 import tools.vitruv.dsls.reactions.language.ElementChangeType
 import tools.vitruv.dsls.reactions.language.ElementReferenceChangeType
 import tools.vitruv.dsls.reactions.language.ModelAttributeChange
@@ -21,244 +13,249 @@ import tools.vitruv.dsls.reactions.language.toplevelelements.ReactionsImport
 import tools.vitruv.dsls.reactions.language.toplevelelements.Routine
 import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineInput
 import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineOverrideImportPath
-import tools.vitruv.dsls.reactions.language.Taggable
 import tools.vitruv.dsls.reactions.language.toplevelelements.Trigger
 import tools.vitruv.dsls.reactions.language.RetrieveOrRequireAbscenceOfModelElement
-import org.eclipse.xtext.xbase.XBinaryOperation
-import org.eclipse.xtext.xbase.XCastedExpression
-import org.eclipse.xtext.common.types.JvmTypeReference
 import tools.vitruv.dsls.common.elements.MetaclassReference
 import tools.vitruv.dsls.common.elements.MetaclassEAttributeReference
 import tools.vitruv.dsls.common.elements.MetaclassEReferenceReference
-import org.eclipse.xtext.formatting2.AbstractFormatter2
 import tools.vitruv.dsls.reactions.language.toplevelelements.CreateBlock
 import tools.vitruv.dsls.reactions.language.toplevelelements.MatchBlock
-import tools.vitruv.dsls.reactions.language.toplevelelements.MatchStatement
 import tools.vitruv.dsls.reactions.language.MatchCheckStatement
 import tools.vitruv.dsls.reactions.language.toplevelelements.UpdateBlock
+import tools.vitruv.dsls.reactions.language.toplevelelements.PreconditionCodeBlock
+import tools.vitruv.dsls.reactions.language.ArbitraryModelChange
+import tools.vitruv.dsls.reactions.language.toplevelelements.RoutineCallBlock
+import org.eclipse.xtext.xbase.formatting2.XbaseFormatter
+import tools.vitruv.dsls.reactions.language.RetrieveModelElement
+import tools.vitruv.dsls.reactions.language.CorrespondingObjectCodeBlock
+import tools.vitruv.dsls.reactions.language.TagCodeBlock
+import tools.vitruv.dsls.reactions.language.RequireAbscenceOfModelElement
+import tools.vitruv.dsls.reactions.language.toplevelelements.NamedJavaElementReference
+import tools.vitruv.dsls.common.elements.NamedMetaclassReference
 
-class ReactionsLanguageFormatter extends AbstractFormatter2 {
-	
+class ReactionsLanguageFormatter extends XbaseFormatter {
+
 	def dispatch void format(ReactionsFile reactionsFile, extension IFormattableDocument document) {
 		reactionsFile.metamodelImports.tail.forEach[prepend [newLine]]
 		reactionsFile.metamodelImports.last?.append[newLines = 2]
-		reactionsFile.formatReactionsFile(document)
-	}
-
-	def formatReactionsFile(ReactionsFile reactionsFile, extension IFormattableDocument document) {
 		reactionsFile.namespaceImports?.importDeclarations?.tail?.forEach[prepend [newLine]]
 		reactionsFile.namespaceImports?.append[newLines = 2]
-		reactionsFile.reactionsSegments.forEach[formatReactionsSegment(document)]
+		reactionsFile.reactionsSegments.forEach[it.format(document)]
 		reactionsFile.reactionsSegments.tail.forEach[prepend [newLines = 4]]
 	}
 
-	def formatReactionsSegment(ReactionsSegment segment, extension IFormattableDocument document) {
-		segment.regionFor.keyword('in reaction to changes in').prepend[newLine]
+	def dispatch void format(ReactionsSegment segment, extension IFormattableDocument document) {
+		segment.regionFor.keywordPairs("in", "reaction").forEach [
+			key.prepend[newLine]
+		]
 		segment.regionFor.keyword('execute').prepend[newLine]
 		segment.reactionsImports.head?.prepend[highPriority; newLines = 2]
-		segment.reactionsImports.forEach[formatReactionsImport(document)]
+		segment.reactionsImports.forEach[it.format(document)]
 		segment.reactionsImports.last?.append[newLines = 2]
-		segment.reactions.forEach[formatReaction(document)]
-		segment.routines.forEach[formatRoutine(document)]
+		segment.reactions.forEach[it.format(document)]
+		segment.routines.forEach[it.format(document)]
 	}
 
-	def formatReactionsImport(ReactionsImport reactionsImport, extension IFormattableDocument document) {
+	def dispatch void format(ReactionsImport reactionsImport, extension IFormattableDocument document) {
 		reactionsImport.prepend[newLine]
 		reactionsImport.regionFor.keyword('import').append[oneSpace]
 	}
 
-	def formatReaction(Reaction reaction, extension IFormattableDocument document) {
+	def dispatch void format(Reaction reaction, extension IFormattableDocument document) {
 		reaction.prepend[newLines = 2]
 		if (reaction.documentation !== null) {
 			reaction.regionFor.keyword('reaction').prepend[newLine]
 		}
 		reaction.regionFor.keyword('reaction').append[oneSpace]
-		reaction.regionFor.keyword('::').prepend[noSpace].append[noSpace]
+		reaction.regionFor.keyword('::').surround[noSpace]
 		reaction.formatInteriorBlock(document)
-		reaction.trigger.formatTrigger(document)
-		reaction.callRoutine.prepend[newLine]
-		reaction.callRoutine.code.formatIndividually(document)
+		reaction.trigger?.format(document)
+		reaction.callRoutine?.format(document)
 	}
 
-	def formatTrigger(Trigger trigger, extension IFormattableDocument document) {
-		trigger.regionFor.keyword('with').prepend[newLine; indent]
-		trigger.formatIndividually(document)
+	def dispatch format(ArbitraryModelChange arbitraryModelChange, extension IFormattableDocument document) {
+		arbitraryModelChange.formatTrigger(document)
+		arbitraryModelChange.regionFor.keywordPairs('any', 'change').forEach [
+			key.surround[oneSpace]
+			value.surround[oneSpace]
+		]
 	}
 
-	def dispatch void formatIndividually(ModelElementChange modelElementChange,
-		extension IFormattableDocument document) {
-		modelElementChange.elementType.formatMetaclassReference(document)
-		modelElementChange.changeType.formatChangeType(document)
-		modelElementChange?.precondition?.code?.formatIndividually(document)
+	def dispatch format(ModelElementChange modelElementChange, extension IFormattableDocument document) {
+		modelElementChange.formatTrigger(document)
+		modelElementChange.regionFor.keyword('element').surround[oneSpace]
+		modelElementChange.elementType?.surround[oneSpace]
+		modelElementChange.elementType.format(document)
+		modelElementChange.changeType?.surround[oneSpace]
+		modelElementChange.changeType?.format(document)
 	}
-	
-	def void formatChangeType(ElementChangeType changeType, extension IFormattableDocument document) {
+
+	def dispatch format(ElementChangeType changeType, extension IFormattableDocument document) {
 		if (changeType instanceof ElementReferenceChangeType) {
-			changeType.feature.formatEReferenceReference(document)
+			changeType.feature.format(document)
 		}
 	}
 
-	def dispatch void formatIndividually(ModelAttributeChange modelAttributeChange,
-		extension IFormattableDocument document) {
-		modelAttributeChange.feature.formatEAttributeReference(document)
+	def dispatch format(ModelAttributeChange modelAttributeChange, extension IFormattableDocument document) {
+		modelAttributeChange.formatTrigger(document)
+		modelAttributeChange.regionFor.keyword('attribute').surround[oneSpace]
+		modelAttributeChange.feature?.surround[oneSpace]
+		modelAttributeChange.feature?.format(document)
 	}
 
-	def formatRoutine(Routine routine, extension IFormattableDocument document) {
+	private def formatTrigger(Trigger trigger, extension IFormattableDocument document) {
+		trigger.regionFor.keyword('after').append[oneSpace]
+		trigger.precondition?.prepend[oneSpace]
+		trigger.precondition?.format(document)
+	}
+
+	def dispatch format(PreconditionCodeBlock precondition, extension IFormattableDocument document) {
+		precondition.code?.prepend[oneSpace]
+		precondition.code?.format(document)
+	}
+
+	def dispatch format(RoutineCallBlock routineCall, extension IFormattableDocument document) {
+		routineCall.prepend[newLine]
+		routineCall.code?.prepend[oneSpace]
+		routineCall.code?.format(document)
+	}
+
+	def dispatch format(Routine routine, extension IFormattableDocument document) {
 		routine.prepend[newLines = 2]
 		if (routine.documentation !== null) {
 			routine.regionFor.keyword('routine').prepend[newLine]
 		}
 		routine.regionFor.keyword('routine').append[oneSpace]
-		routine.overrideImportPath?.formatRoutineOverrideImportPath(document)
-		routine.regionFor.keyword('::').prepend[noSpace].append[noSpace]
-		routine.input.formatRoutineInput(document)
+		routine.overrideImportPath?.format(document)
+		routine.regionFor.keyword('::').surround[noSpace]
+		routine.input?.format(document)
 		routine.formatInteriorBlock(document)
-		routine.matchBlock?.formatMatchBlock(document)
-		routine.createBlock?.formatCreateBlock(document)
-		routine.updateBlock?.formatUpdateBlock(document)
+		routine.matchBlock?.format(document)
+		routine.createBlock?.format(document)
+		routine.updateBlock?.format(document)
 	}
 
-	def formatRoutineOverrideImportPath(RoutineOverrideImportPath routineOverrideImportPath, extension IFormattableDocument document) {
-		routineOverrideImportPath.allRegionsFor.keyword('.').prepend[noSpace].append[noSpace]
+	def dispatch format(RoutineOverrideImportPath routineOverrideImportPath, extension IFormattableDocument document) {
+		routineOverrideImportPath.allRegionsFor.keyword('.').surround[noSpace]
 	}
 
-	def formatRoutineInput(RoutineInput routineInput, extension IFormattableDocument document) {
-		routineInput.regionFor.keyword('(').prepend[noSpace].append[noSpace]
-		routineInput.modelInputElements.forEach[formatMetaclassReference(document)]
+	def dispatch format(RoutineInput routineInput, extension IFormattableDocument document) {
+		routineInput.regionFor.keyword('(').surround[noSpace]
+		routineInput.modelInputElements.forEach [
+			it.format(document)
+		]
+		routineInput.javaInputElements.forEach [
+			it.format(document)
+		]
 		routineInput.allRegionsFor.keyword(',').prepend[noSpace].append[oneSpace]
 		routineInput.regionFor.keyword(')').prepend[noSpace]
 	}
 
-	def formatMatchBlock(MatchBlock match, extension IFormattableDocument document) {
+	def dispatch format(MatchBlock match, extension IFormattableDocument document) {
 		match.prepend[newLine]
+		match.regionFor.keyword('match').append[oneSpace]
 		match.formatInteriorBlock(document)
-		match.matchStatements.forEach[formatMatchStatement(document)]
+		match.matchStatements.forEach[it.format(document)]
 	}
-	
-	
-	def dispatch void formatIndividually(MatchCheckStatement matchCheckStatement,
+
+	def dispatch void format(MatchCheckStatement matchCheckStatement, extension IFormattableDocument document) {
+		matchCheckStatement.prepend[newLine]
+		matchCheckStatement.code?.format(document)
+	}
+
+	def dispatch void format(RetrieveModelElement retrieveStatement, extension IFormattableDocument document) {
+		retrieveStatement.formatAssignment(document)
+		retrieveStatement.formatRetrieveOrRequireAbsence(document)
+	}
+
+	def dispatch void format(RequireAbscenceOfModelElement requireAbsenceStatement,
 		extension IFormattableDocument document) {
-		matchCheckStatement.code?.formatIndividually(document)
+		requireAbsenceStatement.formatRetrieveOrRequireAbsence(document)
 	}
 
-	def formatMatchStatement(MatchStatement matchStatement, extension IFormattableDocument document) {
-		matchStatement.prepend[newLine]
-		matchStatement.formatIndividually(document)
-	}
-
-	def dispatch void formatIndividually(RetrieveOrRequireAbscenceOfModelElement retrieveStatement,
+	private def void formatRetrieveOrRequireAbsence(
+		RetrieveOrRequireAbscenceOfModelElement retrieveOrRequireAbsenceStatment,
 		extension IFormattableDocument document) {
-		retrieveStatement.elementType.formatMetaclassReference(document)
-		retrieveStatement.formatTaggable(document)
+		retrieveOrRequireAbsenceStatment.prepend[newLine]
+		retrieveOrRequireAbsenceStatment.elementType?.format(document)
+		retrieveOrRequireAbsenceStatment.correspondenceSource?.prepend[oneSpace]
+		retrieveOrRequireAbsenceStatment.correspondenceSource?.format(document)
+		retrieveOrRequireAbsenceStatment.tag?.prepend[oneSpace]
+		retrieveOrRequireAbsenceStatment.tag?.format(document)
 	}
 
-	def formatCreateBlock(CreateBlock creator, extension IFormattableDocument document) {
-		creator.prepend[newLine]
-		creator.formatInteriorBlock(document)
-		creator.createStatements.forEach[formatMetaclassReference(document)]
-	}
-	
-	def void formatUpdateBlock(UpdateBlock update, extension IFormattableDocument document) {
-		update.code?.formatIndividually(document)
+	def dispatch format(CorrespondingObjectCodeBlock correspondingObject, extension IFormattableDocument document) {
+		correspondingObject.regionFor.keywordPairs('corresponds', 'to').forEach [
+			key.surround[oneSpace]
+			value.surround[oneSpace]
+		]
+		correspondingObject.code?.format(document)
 	}
 
-	def formatTaggable(Taggable taggable, extension IFormattableDocument document) {
-		taggable.regionFor.keyword('tagged with').prepend[newLine]
+	def dispatch format(TagCodeBlock tag, extension IFormattableDocument document) {
+		tag.regionFor.keywordPairs('tagged', 'with').forEach [
+			key.surround[oneSpace]
+			value.surround[oneSpace]
+		]
+		tag.code?.format(document)
 	}
 
-	def dispatch void formatIndividually(XExpression anyExpression, extension IFormattableDocument document) {}
-
-	def dispatch void formatIndividually(XBlockExpression block, extension IFormattableDocument document) {
-		block.formatInteriorBlock(document)
-		block.expressions.forEach[prepend [newLine]; formatIndividually(document)]
+	def dispatch format(CreateBlock create, extension IFormattableDocument document) {
+		create.prepend[newLine]
+		create.regionFor.keyword('create').append[oneSpace]
+		create.formatInteriorBlock(document)
+		create.createStatements.forEach[it.formatCreateStatement(document)]
 	}
 
-	def dispatch void formatIndividually(XFeatureCall featureCall, extension IFormattableDocument document) {
-		featureCall.regionFor.keyword('(').prepend[noSpace].append[noSpace]
-		featureCall.featureCallArguments.forEach[formatIndividually(document)]
-		featureCall.allRegionsFor.keyword(",").prepend[noSpace].append[oneSpace]
-		featureCall.regionFor.keyword(')').prepend[noSpace]
-	}
-
-	def dispatch void formatIndividually(XMemberFeatureCall memberFeatureCall,
+	private def formatCreateStatement(NamedMetaclassReference createStatement,
 		extension IFormattableDocument document) {
-		memberFeatureCall.memberCallTarget.formatIndividually(document)
-		memberFeatureCall.regionFor.keyword('(').prepend[noSpace].append[noSpace]
-		memberFeatureCall.regionFor.keyword('.').prepend[noSpace].append[noSpace]
-		memberFeatureCall.memberCallArguments.forEach[formatIndividually(document)]
-		memberFeatureCall.allRegionsFor.keyword(",").prepend[noSpace].append[oneSpace]
-		memberFeatureCall.regionFor.keyword(')').prepend[noSpace]
+		createStatement.regionFor.keyword('new').surround[oneSpace]
+		createStatement.formatAssignment(document)
+		createStatement.format(document)
 	}
 
-	def dispatch void formatIndividually(XConstructorCall constructorCall, extension IFormattableDocument document) {
-		constructorCall.regionFor.keyword('new').append[oneSpace]
-		constructorCall.regionFor.keyword('(').prepend[noSpace].append[noSpace]
-		constructorCall.arguments.forEach[formatIndividually(document)]
-		constructorCall.allRegionsFor.keyword(",").prepend[noSpace].append[oneSpace]
-		constructorCall.regionFor.keyword(')').prepend[noSpace]
+	def dispatch format(UpdateBlock update, extension IFormattableDocument document) {
+		update.prepend[newLine]
+		update.regionFor.keyword('update').append[oneSpace]
+		update.code?.format(document)
 	}
 
-	def dispatch void formatIndividually(XListLiteral listLiteral, extension IFormattableDocument document) {
-		listLiteral.regionFor.keyword('#').append[noSpace]
-		listLiteral.regionFor.keyword('[').append[noSpace]
-		listLiteral.regionFor.keyword(']').prepend[noSpace]
-		listLiteral.elements.forEach[formatIndividually(document)]
-		listLiteral.allRegionsFor.keyword(',').prepend[noSpace].append[oneSpace]
+	def dispatch format(MetaclassReference metaclassReference, extension IFormattableDocument document) {
+		metaclassReference.regionFor.keyword('::').surround[noSpace]
 	}
 
-	def dispatch void formatIndividually(XAssignment assignment, extension IFormattableDocument document) {
-		assignment.assignable.formatIndividually(document)
-		assignment.regionFor.keyword('.').prepend[noSpace].append[noSpace]
-		assignment.regionFor.keyword('=').prepend[oneSpace].append[oneSpace]
-		assignment.value.formatIndividually(document)
-	}
-	
-	def dispatch void formatIndividually(XBinaryOperation binaryOperation, extension IFormattableDocument document) {
-		binaryOperation.leftOperand.formatIndividually(document)
-		binaryOperation.rightOperand.formatIndividually(document)
+	def dispatch format(NamedMetaclassReference namedMetaclassReference, extension IFormattableDocument document) {
+		namedMetaclassReference.metaclass?.append[oneSpace]
+		namedMetaclassReference.regionFor.keyword('::').surround[noSpace]
 	}
 
-	def dispatch void formatIndividually(XVariableDeclaration variableDeclaration,
-		extension IFormattableDocument document) {
-		variableDeclaration.right?.formatIndividually(document)
-	}
-	
-	def dispatch void formatIndividually(XCastedExpression cast, extension IFormattableDocument document) {
-		cast.target.formatIndividually(document)
-		cast.type.formatIndividually(document)
-	}
-	
-	def dispatch void formatIndividually(JvmTypeReference typeReference, extension IFormattableDocument document) {
-		typeReference.allRegionsFor.keyword('.').prepend [noSpace].append [noSpace]
-		typeReference.regionFor.keyword('<').prepend [noSpace].append [noSpace]
-		typeReference.allRegionsFor.keyword(',').prepend [noSpace].append [oneSpace]
-		typeReference.regionFor.keyword('>').prepend [noSpace]
+	def dispatch format(NamedJavaElementReference namedJavaElementReference, extension IFormattableDocument document) {
+		namedJavaElementReference.type?.append[oneSpace]
+		namedJavaElementReference.type?.format(document)
 	}
 
-	def formatInteriorBlock(EObject element, extension IFormattableDocument document) {
+	def dispatch format(MetaclassEAttributeReference attributeReference, extension IFormattableDocument document) {
+		attributeReference.format(document)
+		attributeReference.regionFor.keyword('[').prepend[noSpace].append[noSpace]
+		attributeReference.regionFor.keyword(']').prepend[noSpace]
+	}
+
+	def dispatch format(MetaclassEReferenceReference referenceReference, extension IFormattableDocument document) {
+		referenceReference.format(document)
+		referenceReference.regionFor.keyword('[').prepend[noSpace].append[noSpace]
+		referenceReference.regionFor.keyword(']').prepend[noSpace]
+	}
+
+	private def void formatAssignment(EObject assigment, extension IFormattableDocument document) {
+		assigment.regionFor.keyword('val').append[oneSpace]
+		assigment.regionFor.keyword('=').surround[oneSpace]
+	}
+
+	private def formatInteriorBlock(EObject element, extension IFormattableDocument document) {
 		interior(
 			element.regionFor.keyword('{').append[newLine],
 			element.regionFor.keyword('}').prepend[newLine],
 			[indent]
 		)
-	}
-	
-	def protected void formatMetaclassReference(MetaclassReference metaclassReference,
-		extension IFormattableDocument document) {
-		metaclassReference.regionFor.keyword('::').prepend[noSpace].append[noSpace]
-	}
-
-	def protected void formatEAttributeReference(MetaclassEAttributeReference attributeReference,
-		extension IFormattableDocument document) {
-		attributeReference.formatMetaclassReference(document)
-		attributeReference.regionFor.keyword('[').prepend[noSpace].append[noSpace]
-		attributeReference.regionFor.keyword(']').prepend[noSpace]
-	}
-
-	def protected void formatEReferenceReference(MetaclassEReferenceReference referenceReference,
-		extension IFormattableDocument document) {
-		referenceReference.formatMetaclassReference(document)
-		referenceReference.regionFor.keyword('[').prepend[noSpace].append[noSpace]
-		referenceReference.regionFor.keyword(']').prepend[noSpace]
 	}
 }

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
@@ -155,10 +155,14 @@ class ReactionsLanguageFormatter extends XbaseFormatter {
 
 	def dispatch format(Routine routine, extension IFormattableDocument document) {
 		if (routine.documentation !== null) {
-			routine.regionFor.keyword('routine').prepend[newLine]
+			routine.prepend[newLines = 2]
 		}
 		routine.regionFor.keyword('routine') => [
-			prepend[newLines = 2]
+			if (routine.documentation === null) {
+				prepend[newLines = 2]
+			} else {
+				prepend[newLine]
+			}
 			append[oneSpace]
 		]
 		routine.overrideImportPath?.format(document)

--- a/tests/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Require-Bundle: edu.kit.ipd.sdq.activextendannotations,
  org.eclipse.xtext.xtext.generator;bundle-version="2.12.0",
  org.objectweb.asm;bundle-version="[9.1.0,9.2.0)";resolution:=optional,
  org.junit.jupiter.api,
+ org.junit.jupiter.params,
  org.hamcrest.core,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/MultilineTextMatcher.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/MultilineTextMatcher.xtend
@@ -1,0 +1,62 @@
+package tools.vitruv.dsls.reactions.formatting2
+
+import org.hamcrest.TypeSafeMatcher
+import org.hamcrest.Description
+import java.util.function.Consumer
+
+class MultilineTextMatcher extends TypeSafeMatcher<String> {
+	val String expectedText
+	var Consumer<Description> mismatch
+
+	new(String expectedText) {
+		this.expectedText = expectedText
+	}
+	
+	override protected matchesSafely(String item) {
+		val firstMismatchingLines = firstMismatchingLines(item, expectedText)
+		if (firstMismatchingLines !== null) {
+			mismatch = [
+				appendText('text has wrong content').
+					appendText('.\nExpected was:\n\n').appendText(expectedText)
+					.appendText('\n\n But got:\n\n').appendText(item)
+					.appendText('\n\nFirst mismatching line:\n\n')
+					.appendText("\tActual: ").appendValue(firstMismatchingLines.key).appendText("\n")
+					.appendText("\tExpected: ").appendValue(firstMismatchingLines.value)
+			]
+			return false
+		}
+		return true
+	}
+		
+	override describeTo(Description description) {
+		description.appendText("the following text: \n\n").appendText(expectedText)
+	}
+
+	override protected describeMismatchSafely(String item, Description mismatchDescription) {
+		mismatch?.accept(mismatchDescription)
+	}
+	
+	def private static firstMismatchingLines(String firstText, String secondText) {
+		val firstTextLines = firstText.split(System.lineSeparator)
+		val secondTextLines = secondText.split(System.lineSeparator)
+		val numberOfCommonLines = Math.min(firstTextLines.size, secondTextLines.size)
+		for (var lineNumber = 0; lineNumber < numberOfCommonLines; lineNumber++) {
+			val comparedFirstTextLine = firstTextLines.get(lineNumber)
+			val comparedSecondTextLine = secondTextLines.get(lineNumber)
+			if (comparedFirstTextLine != comparedSecondTextLine) {
+				return comparedFirstTextLine -> comparedSecondTextLine
+			}
+		}
+		return if (firstTextLines.size > secondTextLines.size) {
+			firstTextLines.get(numberOfCommonLines) -> ""
+		} else if (secondTextLines.size > firstTextLines.size) {
+			"" -> secondTextLines.get(numberOfCommonLines)
+		} else {
+			null
+		}
+	}
+	
+	static def hasEachLineEqualTo(String expected) {
+		return new MultilineTextMatcher(expected)
+	}
+}

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
@@ -1,0 +1,249 @@
+package tools.vitruv.dsls.reactions.formatting2
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import com.google.inject.Inject
+import org.eclipse.xtext.testing.util.ParseHelper
+import tools.vitruv.dsls.reactions.language.toplevelelements.ReactionsFile
+import java.util.Scanner
+import org.eclipse.xtext.serializer.ISerializer
+import org.eclipse.xtext.resource.SaveOptions
+import org.eclipse.xtext.testing.extensions.InjectionExtension
+import tools.vitruv.dsls.reactions.tests.ReactionsLanguageInjectorProvider
+import org.eclipse.xtext.testing.InjectWith
+import org.junit.jupiter.api.^extension.ExtendWith
+import static tools.vitruv.dsls.reactions.formatting2.MultilineTextMatcher.hasEachLineEqualTo
+import static org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.eclipse.core.runtime.Platform
+import org.junit.jupiter.api.BeforeEach
+import static java.lang.System.lineSeparator
+
+@ExtendWith(InjectionExtension)
+@InjectWith(ReactionsLanguageInjectorProvider)
+class ReactionLanguageFormatterTest {
+	@Inject var extension ParseHelper<ReactionsFile>
+	@Inject var extension ISerializer
+
+	@ParameterizedTest
+	@ValueSource(strings=#[
+		"tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/Direct2SN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/DirectRoutinesQN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/DirectSN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/Root.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/Transitive2SN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/Transitive3SN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesQN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions",
+		"tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions"
+	])
+	def void testAllElementTypesReactions(String filePathInSourceFolder) {
+		val content = filePathInSourceFolder.loadJavaFileContents()
+		assertThat(content.destroyFormatting().format(), hasEachLineEqualTo(content))
+	}
+	
+	private def String loadJavaFileContents(String filePathInSourceFolder) {
+		val classLoader = this.getClass().getClassLoader()
+		val file = if (Platform.isRunning) {
+				new File("src/" + filePathInSourceFolder)
+			} else {
+				new File(classLoader.getResource(filePathInSourceFolder).getFile())
+			}
+		return new Scanner(file).useDelimiter("\\Z").next()
+	}
+
+	@Test
+	def void testAllStatementTypes() {
+		val expected = '''
+		import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
+		import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange
+		import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
+		
+		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal
+		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal2
+		
+		reactions: simpleChangesTests
+		in reaction to changes in minimal
+		execute actions in minimal
+		
+		// A test reaction
+		reaction InsertedNonRoot {
+			after element minimal::NonRoot inserted in minimal::NonRootObjectContainerHelper[nonRootObjectsContainment]
+			call insertNonRoot(newValue)
+		}
+		
+		/*
+		 * This is a routine.
+		 * The only one.
+		 */
+		routine insertNonRoot(minimal::NonRoot nonRootElement) {
+			match {
+				require absence of minimal::NonRoot corresponding to nonRootElement
+				val correspondingContainer = retrieve EObject corresponding to nonRootElement.eContainer tagged "test" with true
+				val optionalCorresponding = retrieve optional minimal::NonRoot corresponding to {
+					nonRootElement
+				} tagged null
+				val correspondingAsIterable = retrieve many minimal::NonRoot corresponding to {
+					return nonRootElement;
+				} with {
+					correspondingAsIterable !== null
+				}
+			}
+			create {
+				val newNonRoot = new minimal::NonRoot
+			}
+			update {
+				if (optionalCorresponding.empty) {
+					// This can never happen due to matcher checks
+				}
+				newNonRoot.id = nonRootElement.id
+				{
+					{
+						newNonRoot.value = "new"
+					}
+				}
+				insertNonRoot(newNonRoot)
+			}
+		}'''
+		assertThat(expected.destroyFormatting.format, hasEachLineEqualTo(expected))
+	}
+
+	/**
+	 * New lines can only be tested when not having Xbase code blocks with more than one line, because
+	 * the Xbase formatter does not remove empty lines.
+	 */
+	@Test
+	def void testProperNewlines() {
+		val expected = '''
+		import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
+		import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange
+		import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
+		
+		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal
+		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal2
+		
+		reactions: simpleChangesTests
+		in reaction to changes in minimal
+		execute actions in minimal
+		
+		reaction InsertedNonRoot {
+			after element minimal::NonRoot inserted in minimal::NonRootObjectContainerHelper[nonRootObjectsContainment]
+			call insertNonRoot(newValue)
+		}
+		
+		routine insertNonRoot(minimal::NonRoot nonRootElement) {
+			match {
+				require absence of minimal::NonRoot corresponding to nonRootElement
+				val correspondingContainer = retrieve EObject corresponding to nonRootElement.eContainer tagged "test" with true
+				val optionalCorresponding = retrieve optional minimal::NonRoot corresponding to {
+					nonRootElement
+				} tagged null
+				val correspondingAsIterable = retrieve many minimal::NonRoot corresponding to {
+					return nonRootElement;
+				} with {
+					correspondingAsIterable !== null
+				}
+			}
+			create {
+				val newNonRoot = new minimal::NonRoot
+			}
+			update {
+			}
+		}'''
+		assertThat(expected.destroyFormatting.format, hasEachLineEqualTo(expected))
+	}
+
+	private def String format(String reactionsCodeToFormat) {
+		return reactionsCodeToFormat.parse.serialize(SaveOptions::newBuilder.format().getOptions())
+	}
+
+	private def String destroyFormatting(String textToUnformat) {
+		return textToUnformat.preserveEmptyLines [
+			applyToEachLineRemovingLinebreaks [
+				if (it.isCommentLine) {
+					it.preserveCommentLine()
+				} else {
+					it.mixUpSpacingTerminals()
+				}
+			]
+		]
+	}
+
+	private def String preserveEmptyLines(String text, (String)=>String applicator) {
+		text.replace(lineSeparator + lineSeparator, lineSeparator + lineSeparator, applicator)
+	}
+
+	private def String applyToEachLineRemovingLinebreaks(String text, (String)=>String applicator) {
+		text.split(lineSeparator).map[applicator.apply(it)].join()
+	}
+
+	private def boolean isCommentLine(String line) {
+		return line.isFirstCommentLine || line.isInnerCommentLine
+	}
+
+	private def boolean isFirstCommentLine(extension String line) {
+		return contains("//") || contains("/*")
+	}
+
+	private def boolean isInnerCommentLine(extension String line) {
+		return contains(" *")
+	}
+
+	private def String preserveCommentLine(extension String line) {
+		if (line.isFirstCommentLine) {
+			return lineSeparator + line + lineSeparator
+		} else if (line.isInnerCommentLine) {
+			return line + lineSeparator
+		} else {
+			throw new IllegalArgumentException("line is no comment: " + line)
+		}
+	}
+
+	private def String mixUpSpacingTerminals(String text) {
+		val result = text.replace(" ", lineSeparator + lineSeparator) [
+			replace("::", "  ::  ") [
+				replace('\t', '  ')
+			]
+		]
+		if (result != "}") {
+			return result + " "
+		} else {
+			return result
+		}
+	}
+
+	private def String replace(String text, String original, String replacement,
+		(String)=>String applyOnIntermediatePlaceholderString) {
+		return text.modifyTextUsingPlaceholderChar [inputText, placeholder|
+			val placeholderString = "" + placeholder
+			val textWithPlaceholder = inputText.replace(original, placeholderString)
+			val modifiedTextWithPlaceholder = applyOnIntermediatePlaceholderString.apply(textWithPlaceholder)
+			val textWithReplacement = modifiedTextWithPlaceholder.replace(placeholderString, replacement)
+			return textWithReplacement	
+		]
+	}
+
+	var char nextPlaceholderChar
+
+	@BeforeEach
+	def void restorePlaceholderChars() {
+		nextPlaceholderChar = 14 as char
+	}
+
+	private def String modifyTextUsingPlaceholderChar(String text, (String, char)=>String modifier) {
+		val result = modifier.apply(text, retrievePlaceholderChar())
+		returnPlaceholderChar()
+		return result
+	}
+
+	private def char retrievePlaceholderChar() {
+		return nextPlaceholderChar++
+	}
+
+	private def void returnPlaceholderChar() {
+		nextPlaceholderChar--
+	}
+}

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.eclipse.core.runtime.Platform
 import org.junit.jupiter.api.BeforeEach
 import static java.lang.System.lineSeparator
+import org.junit.jupiter.api.DisplayName
 
 @ExtendWith(InjectionExtension)
 @InjectWith(ReactionsLanguageInjectorProvider)
@@ -26,7 +27,8 @@ class ReactionLanguageFormatterTest {
 	@Inject var extension ParseHelper<ReactionsFile>
 	@Inject var extension ISerializer
 
-	@ParameterizedTest
+	@DisplayName("reformat existing test classes")
+	@ParameterizedTest(name = "{index} file: {1}")
 	@ValueSource(strings=#[
 		"tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions",
 		"tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions",
@@ -40,7 +42,7 @@ class ReactionLanguageFormatterTest {
 		"tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions",
 		"tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions"
 	])
-	def void testAllElementTypesReactions(String filePathInSourceFolder) {
+	def void testExistingReactionsFilesFormatting(String filePathInSourceFolder) {
 		val content = filePathInSourceFolder.loadJavaFileContents()
 		assertThat(content.destroyFormatting().format(), hasEachLineEqualTo(content))
 	}
@@ -55,6 +57,7 @@ class ReactionLanguageFormatterTest {
 		return new Scanner(file).useDelimiter("\\Z").next()
 	}
 
+	@DisplayName("reformat file with all kinds of Reactions statements")
 	@Test
 	def void testAllStatementTypes() {
 		val expected = '''
@@ -108,52 +111,7 @@ class ReactionLanguageFormatterTest {
 				insertNonRoot(newNonRoot)
 			}
 		}'''
-		assertThat(expected.destroyFormatting.format, hasEachLineEqualTo(expected))
-	}
-
-	/**
-	 * New lines can only be tested when not having Xbase code blocks with more than one line, because
-	 * the Xbase formatter does not remove empty lines.
-	 */
-	@Test
-	def void testProperNewlines() {
-		val expected = '''
-		import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
-		import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange
-		import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
-		
-		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal
-		import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal2
-		
-		reactions: simpleChangesTests
-		in reaction to changes in minimal
-		execute actions in minimal
-		
-		reaction InsertedNonRoot {
-			after element minimal::NonRoot inserted in minimal::NonRootObjectContainerHelper[nonRootObjectsContainment]
-			call insertNonRoot(newValue)
-		}
-		
-		routine insertNonRoot(minimal::NonRoot nonRootElement) {
-			match {
-				require absence of minimal::NonRoot corresponding to nonRootElement
-				val correspondingContainer = retrieve EObject corresponding to nonRootElement.eContainer tagged "test" with true
-				val optionalCorresponding = retrieve optional minimal::NonRoot corresponding to {
-					nonRootElement
-				} tagged null
-				val correspondingAsIterable = retrieve many minimal::NonRoot corresponding to {
-					return nonRootElement;
-				} with {
-					correspondingAsIterable !== null
-				}
-			}
-			create {
-				val newNonRoot = new minimal::NonRoot
-			}
-			update {
-			}
-		}'''
-		assertThat(expected.destroyFormatting.format, hasEachLineEqualTo(expected))
+		assertThat(expected.destroyFormatting().format(), hasEachLineEqualTo(expected))
 	}
 
 	private def String format(String reactionsCodeToFormat) {

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
@@ -191,6 +191,12 @@ class ReactionLanguageFormatterTest {
 		nextPlaceholderChar = 14 as char
 	}
 
+	/*
+	 * We temporarily replace formatting sequences (such as whitespaces, tabs, newlines etc.)
+	 * with placeholders to restore different formatting sequences later on.
+	 * To this end, we use usually unused ASCII symbols as placeholders, specifically
+	 * the ASCII symbols 14 to 31.
+	 */
 	private def String modifyTextUsingPlaceholderChar(String text, (String, char)=>String modifier) {
 		val result = modifier.apply(text, retrievePlaceholderChar())
 		returnPlaceholderChar()
@@ -198,6 +204,9 @@ class ReactionLanguageFormatterTest {
 	}
 
 	private def char retrievePlaceholderChar() {
+		if (nextPlaceholderChar > 31) {
+			throw new IllegalStateException("Too many placeholder chars are used")
+		}
 		return nextPlaceholderChar++
 	}
 

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
@@ -5,7 +5,7 @@ import tools.vitruv.change.atomic.^root.RootEChange
 import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange
 import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
 
-import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal 
+import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal
 
 reactions: simpleChangesTests
 in reaction to changes in minimal
@@ -28,7 +28,8 @@ routine createRoot(minimal::Root rootElement) {
 	}
 	update {
 		newRoot.id = rootElement.id
-		val targetModel = rootElement.eResource.URI.trimFileExtension.lastSegment.replace('Source', 'Target').allElementTypes 
+		val targetModel = rootElement.eResource.URI.trimFileExtension.lastSegment.replace('Source', 'Target').
+			allElementTypes
 		persistProjectRelative(rootElement, newRoot, targetModel.toString)
 		addCorrespondenceBetween(newRoot, rootElement)
 	}
@@ -78,9 +79,13 @@ reaction ReplacedSingleValuedEAttribute {
 routine replaceSingleValuedEAttribute(minimal::Root rootElement, Integer value) {
 	match {
 		// The check statements do only test that multiple check statements work
-		check asserted { rootElement !== null }
+		check asserted {
+			rootElement !== null
+		}
 		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
-		check { value !== null }
+		check {
+			value !== null
+		}
 	}
 	update {
 		targetElement.singleValuedEAttribute = value;
@@ -141,7 +146,7 @@ routine removeNonRoot(minimal::NonRoot removedNonRoot) {
 	match {
 		val targetElement = retrieve minimal::NonRoot corresponding to removedNonRoot
 	}
-	update{
+	update {
 		SimpleChangesTestsExecutionMonitor.instance.set(DeleteNonRootEObjectInList);
 		removeObject(targetElement)
 		removeCorrespondenceBetween(targetElement, removedNonRoot)
@@ -166,8 +171,8 @@ reaction ReplacedNonRootEObjectSingleReupdate {
 routine deleteNonRootEObjectSingle(minimal::Root container, minimal::NonRoot containedObject) {
 	match {
 		val correspondingContainer = retrieve asserted minimal::Root corresponding to container
-		val targetElement = retrieve minimal::NonRoot corresponding to containedObject
-			with targetElement.eContainer === correspondingContainer
+		val targetElement = retrieve minimal::NonRoot corresponding to containedObject with targetElement.eContainer ===
+			correspondingContainer
 	}
 	update {
 		removeObject(targetElement)
@@ -200,8 +205,7 @@ reaction ReplacedSingleValuedNonContainmentEReference {
 	call replaceSingleValuedNonContainmentReference(affectedEObject, newValue)
 }
 
-routine replaceSingleValuedNonContainmentReference(minimal::Root rootElement, minimal::NonRoot newReferencedElement
-) {
+routine replaceSingleValuedNonContainmentReference(minimal::Root rootElement, minimal::NonRoot newReferencedElement) {
 	match {
 		val targetContainer = retrieve asserted minimal::Root corresponding to rootElement
 		val targetElement = retrieve asserted minimal::NonRoot corresponding to newReferencedElement
@@ -262,12 +266,13 @@ routine insertNonContainmentReference(minimal::Root rootElement, minimal::NonRoo
 		val targetElement = retrieve asserted minimal::Root corresponding to rootElement
 	}
 	update {
-		val addedNonRoot = targetElement.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst[it.id == insertedNonRoot.id];
+		val addedNonRoot = targetElement.nonRootObjectContainerHelper.nonRootObjectsContainment.findFirst [
+			it.id == insertedNonRoot.id
+		];
 		targetElement.multiValuedNonContainmentEReference += addedNonRoot;
 		SimpleChangesTestsExecutionMonitor.instance.set(InsertNonContainmentEReference);
 	}
 }
-
 
 /*
  * RemoveNonContainmentEReference
@@ -287,14 +292,12 @@ routine removeNonContainmentReference(minimal::Root rootElement, minimal::NonRoo
 	}
 }
 
-
-
 /**
  * Initializes the nonRootObjectContainer for second model
  */
 reaction HelperReactionForNonRootObjectContainerInitialization {
 	after element minimal::NonRootObjectContainerHelper replaced at minimal::Root[nonRootObjectContainerHelper]
-		with newValue !== null
+	with newValue !== null
 	call createNonRootObjectContainer(affectedEObject, newValue)
 }
 
@@ -382,8 +385,11 @@ routine testPrimitiveTypesRoutine(Integer intVal, Long longVal, Short shortVal, 
 // Unused reaction: Only check, that change is available when reacting to any change
 reaction AnyChange {
 	after anychange
-	with change instanceof FeatureChange || change instanceof RootEChange || change instanceof EObjectExistenceEChange<?>
-	call { change.eClass }
+	with change instanceof FeatureChange || change instanceof RootEChange ||
+		change instanceof EObjectExistenceEChange<?>
+	call {
+		change.eClass
+	}
 }
 
 routine testJavaTypes(plain SimpleChangesTestsExecutionMonitor as monitor) {
@@ -398,7 +404,9 @@ reaction CheckManyCorrespondenceRetrievalWorks {
 routine checkManyCorrespondenceRetrievalWorks(minimal::Root rootElement) {
 	match {
 		val targetElements = retrieve many minimal::Root corresponding to rootElement
-		check asserted { return targetElements !== null && !targetElements.empty }
+		check asserted {
+			return targetElements !== null && !targetElements.empty
+		}
 	}
 	update {
 	}

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 
 import "http://tools.vitruv.testutils.metamodels.allElementTypes" as minimal

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Direct2SN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Direct2SN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/DirectRoutinesQN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/DirectRoutinesQN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/DirectSN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/DirectSN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
@@ -68,7 +67,6 @@ routine directSNInnerRoutine() {
 }
 
 // reaction overrides:
-
 reaction DirectSNOverriddenReupdate {
 	after attribute replaced at minimal::Root[id]
 	call {
@@ -103,8 +101,7 @@ reaction importTestsTransitiveSN::TransitiveSNOverriddenReaction3 {
 }
 
 // routine overrides:
-
-routine directSNOverriddenRoutine(){
+routine directSNOverriddenRoutine() {
 	update {
 		ImportTestsExecutionMonitor.instance.set(DirectSNOverriddenRoutine)
 		directSNRoutine()

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Root.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Root.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
@@ -133,7 +132,6 @@ routine callRoutinesFromRoutine(String data) {
 }
 
 // reaction overrides:
-
 reaction importTestsDirectSN::DirectSNOverriddenReupdate {
 	after attribute replaced at minimal::Root[id]
 	call {
@@ -168,8 +166,7 @@ reaction importTestsTransitiveSN::TransitiveSNOverriddenReaction2 {
 }
 
 // routine overrides:
-
-routine importTestsDirectSN::directSNOverriddenRoutine(){
+routine importTestsDirectSN::directSNOverriddenRoutine() {
 	update {
 		ImportTestsExecutionMonitor.instance.set(RootDirectSNOverriddenRoutine)
 		rootRoutine()

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Transitive2SN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Transitive2SN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Transitive3SN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/Transitive3SN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
@@ -32,8 +31,7 @@ routine transitive3SNRoutine() {
 }
 
 // routine overrides:
-
-routine transitive3SNOverriddenRoutine(){
+routine transitive3SNOverriddenRoutine() {
 	update {
 		ImportTestsExecutionMonitor.instance.set(Transitive3SNOverriddenRoutine)
 		transitive3SNRoutine()

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesQN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesQN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions
@@ -1,5 +1,4 @@
 import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
@@ -59,7 +58,6 @@ routine transitiveSNInnerRoutine() {
 }
 
 // reaction overrides:
-
 reaction TransitiveSNOverriddenReupdate {
 	after attribute replaced at minimal::Root[id]
 	call {
@@ -94,8 +92,7 @@ reaction TransitiveSNOverriddenReaction3 {
 }
 
 // routine overrides:
-
-routine transitiveSNOverriddenRoutine(){
+routine transitiveSNOverriddenRoutine() {
 	update {
 		ImportTestsExecutionMonitor.instance.set(TransitiveSNOverriddenRoutine)
 		transitiveSNRoutine()


### PR DESCRIPTION
This PR fixes the Reactions formatter. To this end, it modifies the language itself, as the language was not compatible with the Xtext `Formatter2` (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=485118 for details).
It also provides regression tests for the formatter based on synthetic files as well as the Reactions files already provided in the Reactions tests project.

In more detail it does the following:
- Simplifies the Reactions language grammar by removing unnecessary code blocks and integrating properly named code blocks into the specific rules.
- Adapts the Reactions language to conform to the `Formatter2`, which particularly requires some duplication in rules
- Simplifies the keyword `tagged with` when retrieving a correspondence to `tagged`.
- Rewrites and improves the Reactions formatter: The previous formatter was not working at all, but it was also incomplete.
- Integratese Xbase formatter into Reactions formatter, such that all code blocks are properly formatter
- Adds regression tests for the formatter based on automatically destroying the formatting of an input file and validating the reformatted file against the input. It tests a synthetic file containing all kinds of statements, as well as all Reactions file we have in the test project anyway.
- Reformats all Reactions code in tests projects and demo applications

You can also get an impression of how the formatted Reactions files look like in the applications PR that applies the formatter to the applications projects: vitruv-tools/Vitruv-Applications-ComponentBasedSystems#219