### PR TITLE
Improve Reaction condition methods parameter name

### DIFF
--- a/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
+++ b/bundles/tools.vitruv.applications.demo.familiespersons/src/tools/vitruv/applications/demo/familiespersons/families2persons/FamiliesToPersons.reactions
@@ -179,7 +179,7 @@ routine createFemale(families::Member newMember, families::Family family) {
 routine updateNameAndCorrespondencesAfterMemberBecameFather(families::Member newFather, families::Family newFamily) {
 	match {
 		val correspondingPerson = retrieve persons::Person corresponding to newFather with {
-			assertMale(correspondingPerson)
+			assertMale(it)
 			true
 		}
 	}
@@ -194,7 +194,7 @@ routine updateNameAndCorrespondencesAfterMemberBecameFather(families::Member new
 routine updateNameAndCorrespondencesAfterMemberBecameMother(families::Member newMother, families::Family newFamily) {
 	match {
 		val correspondingPerson = retrieve persons::Person corresponding to newMother with {
-			assertFemale(correspondingPerson)
+			assertFemale(it)
 			true
 		}
 	}
@@ -224,7 +224,7 @@ routine updateNameAndCorrespondencesOfCorrespondingPerson(families::Member newMe
 routine existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(families::Member insertedChild, families::Family newFamily) {
 	match {
 		val correspondingPerson = retrieve persons::Person corresponding to insertedChild with {
-			assertMale(correspondingPerson)
+			assertMale(it)
 			true
 		}
 	}
@@ -237,7 +237,7 @@ routine existingMemberBecameSon_updateNameAndCorrespondencesOfCorrespondingMale(
 routine existingMemberBecameDaughter_updateNameAndCorrespondencesOfCorrespondingFemale(families::Member insertedChild, families::Family newFamily) {
 	match {
 		val correspondingPerson = retrieve persons::Person corresponding to insertedChild with {
-			assertFemale(correspondingPerson)
+			assertFemale(it)
 			true
 		}
 	}

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
@@ -5,7 +5,6 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 @Utility class ReactionsLanguageConstants {
 	public static val OVERRIDDEN_REACTIONS_SEGMENT_SEPARATOR = "::";
 	
-	public static val RETRIEVAL_PRECONDITION_METHOD_TARGET = "potentialTarget"
 	static val ROUTINES_FACADE_NAME = "routinesFacade";
 	public static val ROUTINES_FACADE_PARAMETER_NAME = ROUTINES_FACADE_NAME;
 	static val USER_INTERACTING_NAME = "userInteractor";

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
@@ -8,7 +8,6 @@ import org.eclipse.xtext.common.types.JvmOperation
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
 import tools.vitruv.dsls.reactions.language.RetrieveOrRequireAbscenceOfModelElement
 import tools.vitruv.dsls.reactions.language.RetrieveModelElement
-import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.RETRIEVAL_PRECONDITION_METHOD_TARGET
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import tools.vitruv.dsls.reactions.language.RetrieveManyModelElements
 import tools.vitruv.dsls.reactions.language.RetrieveOneModelElement
@@ -217,9 +216,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		val preconditionMethod = generateMethodCorrespondencePrecondition(retrieveElement, name,
 			currentlyAccessibleElements)
 		return '''(«affectedElementClass» _element) -> «preconditionMethod.simpleName»(« //
-			preconditionMethod.generateMethodParameterCallList.toString.replace(name?: 
-				RETRIEVAL_PRECONDITION_METHOD_TARGET, "_element"
-			)»)'''
+			preconditionMethod.generateMethodParameterCallList.toString.replace("it", "_element")»)'''
 	}
 
 	private def StringConcatenationClient getGeneralGetCorrespondingElementStatementArguments(
@@ -254,7 +251,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		val methodName = "getCorrespondingModelElementsPrecondition" +
 			(elementRetrieve.retrieveOrRequireAbscenceMethodSuffix ?: counterGetCorrespondenceSource++)
 		return elementRetrieve.precondition?.generateAndAddMethod(methodName, typeRef(Boolean.TYPE)) [
-			val element = new AccessibleElement(name ?: RETRIEVAL_PRECONDITION_METHOD_TARGET, elementRetrieve.elementType.javaClassName)
+			val element = new AccessibleElement("it", elementRetrieve.elementType.javaClassName)
 			parameters += generateParameters(currentlyAccessibleElements)
 			parameters += generateParameter(element)
 			body = elementRetrieve.precondition

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
@@ -16,7 +16,6 @@ import java.util.List
 import tools.vitruv.dsls.reactions.language.RequireAbscenceOfModelElement
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.mapFixed
 import java.io.IOException
-import org.eclipse.xtext.common.types.JvmFormalParameter
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageHelper.*
 import static com.google.common.base.Preconditions.checkNotNull
 import static com.google.common.base.Preconditions.checkArgument
@@ -35,7 +34,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	static val PREDEFINED_HAS_CORRESPONDING_ELEMENTS_METHOD_NAME = "hasCorrespondingElements"
 	static val PREDEFINED_GET_CORRESPONDING_ELEMENT_METHOD_NAME = "getCorrespondingElement"
 	static val PREDEFINED_GET_CORRESPONDING_ELEMENTS_METHOD_NAME = "getCorrespondingElements"
-	
+
 	static val MATCH_METHOD_NAME = "match"
 	static val MISSING_TYPE = "/* Type missing */"
 	static val RETRIEVED_ELEMENTS_SIMPLE_CLASS_NAME = "RetrievedValues"
@@ -156,10 +155,10 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	private def dispatch StringConcatenationClient createStatements(RetrieveOneModelElement retrieveElement,
 		String name, String typeName, StringConcatenationClient generalArguments) {
 		val retrieveStatement = '''
-			«PREDEFINED_GET_CORRESPONDING_ELEMENT_METHOD_NAME»(
-				«generalArguments», 
-				«retrieveElement.asserted» // asserted
-			)'''
+		«PREDEFINED_GET_CORRESPONDING_ELEMENT_METHOD_NAME»(
+			«generalArguments», 
+			«retrieveElement.asserted» // asserted
+		)'''
 		if (name.nullOrEmpty) {
 			if (!retrieveElement.optional) {
 				return '''if («retrieveStatement» == null) {
@@ -187,13 +186,13 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		val checkMethod = generateMethodMatcherPrecondition(checkStatement, currentlyAccessibleElements)
 		val checkMethodCall = checkMethod?.userExecutionMethodCallString
 		return '''
-			if (!«checkMethodCall») {
-				«IF checkStatement.asserted»
-					throw new «IllegalStateException»();
-				«ELSE»
-					return null;
-				«ENDIF»
-			}'''
+		if (!«checkMethodCall») {
+			«IF checkStatement.asserted»
+				throw new «IllegalStateException»();
+			«ELSE»
+				return null;
+			«ENDIF»
+		}'''
 	}
 
 	private def StringConcatenationClient getTagString(RetrieveOrRequireAbscenceOfModelElement retrieveElement,
@@ -216,7 +215,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		val preconditionMethod = generateMethodCorrespondencePrecondition(retrieveElement, name,
 			currentlyAccessibleElements)
 		return '''(«affectedElementClass» _element) -> «preconditionMethod.simpleName»(« //
-			preconditionMethod.generateMethodParameterCallList.toString.replace("it", "_element")»)'''
+		FOR parameter : preconditionMethod.parameters.filterNull SEPARATOR ', '»«if (parameter.name == "it") "_element" else parameter.name»«ENDFOR»)'''
 	}
 
 	private def StringConcatenationClient getGeneralGetCorrespondingElementStatementArguments(
@@ -230,10 +229,10 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		val correspondenceSourceMethodCall = correspondenceSourceMethod?.userExecutionMethodCallString
 		val tagString = getTagString(retrieveElement, currentlyAccessibleElements)
 		return '''
-			«correspondenceSourceMethodCall», // correspondence source supplier
-			«affectedElementClass ?: MISSING_TYPE».class,
-			«correspondingElementPreconditionChecker», // correspondence precondition checker
-			«tagString»'''
+		«correspondenceSourceMethodCall», // correspondence source supplier
+		«affectedElementClass ?: MISSING_TYPE».class,
+		«correspondingElementPreconditionChecker», // correspondence precondition checker
+		«tagString»'''
 	}
 
 	private def JvmOperation generateMethodGetRetrieveTag(RetrieveOrRequireAbscenceOfModelElement elementRetrieve,
@@ -270,7 +269,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	}
 
 	private def String getUserExecutionMethodCallString(JvmOperation method) '''
-	«method.simpleName»(«method.generateMethodParameterCallList»)'''
+	«method.simpleName»(«FOR parameter : method.parameters.filterNull SEPARATOR ', '»«parameter.name»«ENDFOR»)'''
 
 	private def JvmOperation generateMethodMatcherPrecondition(MatchCheckStatement checkStatement,
 		Iterable<AccessibleElement> currentlyAccessibleElements) {
@@ -293,13 +292,6 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 		}
 	}
 
-	private def generateMethodParameterCallList(JvmOperation method) {
-		return method.parameters.generateMethodParameterCallList
-	}
-
-	private def generateMethodParameterCallList(Iterable<JvmFormalParameter> parameters) '''
-	«FOR parameter : parameters.filterNull SEPARATOR ', '»«parameter.name»«ENDFOR»'''
-
 	override generateStepExecutionCode(
 		StringConcatenationClient prefix,
 		String executionStateAccessExpression,
@@ -313,7 +305,9 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	'''
 
 	override Iterable<AccessibleElement> getNewlyAccessibleElementsAfterExecution() {
-		return matchBlock.matchStatements.filter(RetrieveModelElement).filter[!name.nullOrEmpty].mapFixed[accessibleElement]
+		return matchBlock.matchStatements.filter(RetrieveModelElement).filter[!name.nullOrEmpty].mapFixed [
+			accessibleElement
+		]
 	}
 
 	private def getAccessibleElement(RetrieveModelElement retrieveElement) {
@@ -335,7 +329,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 	override getNewlyAccessibleElementsContainerType() {
 		return retrievedElementsClass
 	}
-	
+
 	def JvmOperation generateAndAddMethod(EObject contextObject, String methodName, JvmTypeReference returnType,
 		Procedure1<? super JvmOperation> initializer) {
 		val generatedMethod = contextObject.toMethod(methodName, returnType, initializer)

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
@@ -171,7 +171,7 @@ reaction ReplacedNonRootEObjectSingleReupdate {
 routine deleteNonRootEObjectSingle(minimal::Root container, minimal::NonRoot containedObject) {
 	match {
 		val correspondingContainer = retrieve asserted minimal::Root corresponding to container
-		val targetElement = retrieve minimal::NonRoot corresponding to containedObject with targetElement.eContainer ===
+		val targetElement = retrieve minimal::NonRoot corresponding to containedObject with eContainer ===
 			correspondingContainer
 	}
 	update {


### PR DESCRIPTION
With this PR, the `with` block of a retrieve statement in a matcher does not reference to the element to check via the name of the variable the potential element is assigned to or a default name if no such name is specified, but rather uses `it`. First, this is a rather intuitive name, and second, this allows to implicitly reference the element in the `with` block without explicitly stating the variable name, due to Xbase implicitly addressing fields and methods of `it` without explicitly stating `it`.
See also the discussion in #9.

Fixes #9.