### PR TITLE
Minor languages cleanup

### DIFF
--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/builder/FluentReactionsSegmentChildBuilder.xtend
@@ -7,7 +7,7 @@ import org.eclipse.xtext.xbase.XBlockExpression
 import org.eclipse.xtext.xbase.XExpression
 import org.eclipse.xtext.xbase.XbaseFactory
 
-import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*
+import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.CALL_BLOCK_FACADE_PARAMETER_NAME
 
 abstract package class FluentReactionsSegmentChildBuilder extends FluentReactionElementBuilder {
 
@@ -86,6 +86,6 @@ abstract package class FluentReactionsSegmentChildBuilder extends FluentReaction
 	}
 
 	def getJvmOperationRoutineFacade(XExpression codeBlock) {
-		codeBlock.correspondingMethodParameter(REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME).featureCall
+		codeBlock.correspondingMethodParameter(CALL_BLOCK_FACADE_PARAMETER_NAME).featureCall
 	}
 }

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
@@ -5,16 +5,6 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 @Utility class ReactionsLanguageConstants {
 	public static val OVERRIDDEN_REACTIONS_SEGMENT_SEPARATOR = "::";
 	
-	static val ROUTINES_FACADE_NAME = "routinesFacade";
-	public static val ROUTINES_FACADE_PARAMETER_NAME = ROUTINES_FACADE_NAME;
-	static val USER_INTERACTING_NAME = "userInteractor";
-	public static val USER_INTERACTING_PARAMETER_NAME = USER_INTERACTING_NAME;
-	public static val USER_INTERACTING_FIELD_NAME = USER_INTERACTING_NAME;
-	static val REACTION_EXECUTION_STATE_NAME = "reactionExecutionState";
-	public static val REACTION_EXECUTION_STATE_PARAMETER_NAME = REACTION_EXECUTION_STATE_NAME;
-	public static val REACTION_EXECUTION_STATE_FIELD_NAME = REACTION_EXECUTION_STATE_NAME;
-	public static val CHANGE_PARAMETER_NAME = "change";
-	
 	public static val REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME = "_routinesFacade"
 	
 	public static val CHANGE_AFFECTED_ELEMENT_ATTRIBUTE = "affectedEObject"

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
@@ -5,7 +5,7 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 @Utility class ReactionsLanguageConstants {
 	public static val OVERRIDDEN_REACTIONS_SEGMENT_SEPARATOR = "::";
 	
-	public static val REACTION_USER_EXECUTION_ROUTINE_CALL_FACADE_PARAMETER_NAME = "_routinesFacade"
+	public static val CALL_BLOCK_FACADE_PARAMETER_NAME = "_routinesFacade"
 	
 	public static val CHANGE_AFFECTED_ELEMENT_ATTRIBUTE = "affectedEObject"
 	public static val CHANGE_AFFECTED_FEATURE_ATTRIBUTE = "affectedFeature"

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/ReactionClassGenerator.xtend
@@ -19,6 +19,7 @@ import tools.vitruv.dsls.reactions.runtime.routines.RoutinesFacade
 import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 import java.util.function.Function
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
+import tools.vitruv.change.atomic.EChange
 
 class ReactionClassGenerator extends ClassGenerator {
 	static val EXECUTION_STATE_VARIABLE = "executionState"
@@ -86,7 +87,7 @@ class ReactionClassGenerator extends ClassGenerator {
 		val userDefinedPreconditionMethod = generateUserDefinedPreconditionMethod
 		val executeReactionMethod = reaction.toMethod(EXECUTE_REACTION_METHOD_NAME, typeRef(Void.TYPE)) [
 			visibility = JvmVisibility.PUBLIC
-			val changeParameter = generateUntypedChangeParameter
+			val changeParameter = generateParameter(new AccessibleElement("change", EChange))
 			val reactionExecutionStateParameter = generateParameter(new AccessibleElement(EXECUTION_STATE_VARIABLE, ReactionExecutionState))
 			val routinesFacadeParameter = generateParameter(new AccessibleElement(ROUTINES_FACADE_VARIABLE + "Untyped", RoutinesFacade))
 			parameters += changeParameter
@@ -129,7 +130,7 @@ class ReactionClassGenerator extends ClassGenerator {
 
 	private def JvmOperation generateMatchChangeMethod() {
 		return reaction.trigger.toMethod(MATCH_CHANGE_METHOD_NAME, typeRef(Boolean.TYPE)) [
-			val changeParameter = generateUntypedChangeParameter(reaction)
+			val changeParameter = generateParameter(new AccessibleElement("change", EChange))
 			visibility = JvmVisibility.PUBLIC
 			parameters += changeParameter
 			body = changeType.generateCheckMethodBody(changeParameter.name)

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/RoutineClassGenerator.xtend
@@ -19,6 +19,7 @@ import org.eclipse.xtend2.lib.StringConcatenationClient
 import tools.vitruv.dsls.reactions.codegen.classgenerators.steps.EmptyStepExecutionClassGenerator
 import tools.vitruv.dsls.reactions.codegen.classgenerators.steps.StepExecutionClassGenerator
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 class RoutineClassGenerator extends ClassGenerator {
 	static val EXECUTION_STATE_VARIABLE = "getExecutionState()"
@@ -39,7 +40,8 @@ class RoutineClassGenerator extends ClassGenerator {
 	val StepExecutionClassGenerator matchBlockClassGenerator
 	val StepExecutionClassGenerator createBlockClassGenerator
 	val StepExecutionClassGenerator updateBlockClassGenerator
-
+	val String routinesFacadeQualifiedName
+	
 	val JvmGenericType inputValuesClass
 	var JvmGenericType generatedClass
 
@@ -50,6 +52,7 @@ class RoutineClassGenerator extends ClassGenerator {
 		}
 		this.routine = routine
 		this.routineClassNameGenerator = routine.routineClassNameGenerator
+		this.routinesFacadeQualifiedName = routine.reactionsSegment.routinesFacadeClassNameGenerator.qualifiedName
 		this.inputElements = getInputElements(routine.input.modelInputElements, routine.input.javaInputElements)
 		this.inputValuesClass = if (hasInputValues) {
 			generateElementsContainerClass(INPUT_VALUES_SIMPLE_CLASS_NAME, inputElements)
@@ -66,7 +69,6 @@ class RoutineClassGenerator extends ClassGenerator {
 		} else {
 			new EmptyStepExecutionClassGenerator(typesBuilderExtensionProvider)
 		}
-		val routinesFacadeQualifiedName = routine.reactionsSegment.routinesFacadeClassNameGenerator.qualifiedName
 		val updateAccessibleElements = inputElements + matchBlockClassGenerator.newlyAccessibleElementsAfterExecution +
 			createBlockClassGenerator.newlyAccessibleElementsAfterExecution
 		this.updateBlockClassGenerator = if (routine.updateBlock !== null) {
@@ -118,8 +120,8 @@ class RoutineClassGenerator extends ClassGenerator {
 	private def JvmConstructor generateConstructor(Routine routine) {
 		return routine.toConstructor [
 			visibility = JvmVisibility.PUBLIC
-			val routinesFacadeParameter = generateRoutinesFacadeParameter(routine.reactionsSegment)
-			val executionStateParameter = generateReactionExecutionStateParameter()
+			val routinesFacadeParameter = generateParameter(new AccessibleElement("routinesFacade", routinesFacadeQualifiedName))
+			val executionStateParameter = generateParameter(new AccessibleElement("reactionExecutionState", ReactionExecutionState))
 			val calledByParameter = generateParameter(new AccessibleElement("calledBy", CallHierarchyHaving))
 			val inputParameters = routine.generateParameters(inputElements)
 			parameters += routinesFacadeParameter

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/CreateBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/CreateBlockClassGenerator.xtend
@@ -14,6 +14,7 @@ import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.mapF
 import tools.vitruv.dsls.reactions.language.toplevelelements.CreateBlock
 import tools.vitruv.dsls.common.elements.NamedMetaclassReference
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Generates for a {@link CreateBlock} of a routine a class providing a creation method (with the name defined in {@link #CREATE_ELEMENTS_METHOD_NAME})
@@ -84,7 +85,7 @@ class CreateBlockClassGenerator extends StepExecutionClassGenerator {
 
 	def private generateConstructor() {
 		createBlock.toConstructor [
-			val reactionExecutionStateParameter = generateReactionExecutionStateParameter()
+			val reactionExecutionStateParameter = generateParameter(new AccessibleElement("reactionExecutionState", ReactionExecutionState))
 			parameters += reactionExecutionStateParameter
 			body = '''super(«reactionExecutionStateParameter.name»);'''
 		]

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/MatchBlockClassGenerator.xtend
@@ -24,6 +24,7 @@ import tools.vitruv.dsls.reactions.language.MatchCheckStatement
 import org.eclipse.xtext.common.types.JvmTypeReference
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure1
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Generates for a {@link Matcher} block of a routine a class providing a method (with the name defined in 
@@ -92,7 +93,7 @@ class MatchBlockClassGenerator extends StepExecutionClassGenerator {
 
 	private def generateConstructor() {
 		matchBlock.toConstructor [
-			val executionStateParameter = generateReactionExecutionStateParameter()
+			val executionStateParameter = generateParameter(new AccessibleElement("reactionExecutionState", ReactionExecutionState))
 			parameters += executionStateParameter
 			body = '''super(«executionStateParameter.name»);'''
 		]

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
@@ -11,6 +11,7 @@ import static com.google.common.base.Preconditions.checkNotNull
 import org.eclipse.xtend2.lib.StringConcatenationClient
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
 import tools.vitruv.dsls.reactions.language.toplevelelements.CodeExecutionBlock
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Generates for an {@link UpdateBlock} of a routine a class with a method (with the name defined in 
@@ -68,7 +69,7 @@ class UpdateBlockClassGenerator extends StepExecutionClassGenerator {
 
 	private def generateConstructor() {
 		updateBlock.toConstructor [
-			val reactionExecutionStateParameter = generateReactionExecutionStateParameter()
+			val reactionExecutionStateParameter = generateParameter(new AccessibleElement("reactionExecutionState", ReactionExecutionState))
 			parameters += reactionExecutionStateParameter
 			body = '''super(«reactionExecutionStateParameter.name»);'''
 		]

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/classgenerators/steps/UpdateBlockClassGenerator.xtend
@@ -12,6 +12,7 @@ import org.eclipse.xtend2.lib.StringConcatenationClient
 import tools.vitruv.dsls.reactions.runtime.routines.AbstractRoutine
 import tools.vitruv.dsls.reactions.language.toplevelelements.CodeExecutionBlock
 import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
+import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.CALL_BLOCK_FACADE_PARAMETER_NAME
 
 /**
  * Generates for an {@link UpdateBlock} of a routine a class with a method (with the name defined in 
@@ -20,7 +21,7 @@ import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
  */
 class UpdateBlockClassGenerator extends StepExecutionClassGenerator {
 	static val UPDATE_MODELS_METHOD_NAME = "updateModels"
-	static val ROUTINES_FACADE_CLASS_PARAMETER_NAME = "_routinesFacade"
+	static val ROUTINES_FACADE_CLASS_PARAMETER_NAME = CALL_BLOCK_FACADE_PARAMETER_NAME
 
 	val String qualifiedClassName
 	val CodeExecutionBlock updateBlock

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/typesbuilder/ParameterGenerator.xtend
@@ -3,15 +3,10 @@ package tools.vitruv.dsls.reactions.codegen.typesbuilder
 import org.eclipse.xtext.xbase.jvmmodel.JvmTypeReferenceBuilder
 import org.eclipse.xtext.common.types.JvmFormalParameter
 import org.eclipse.emf.ecore.EObject
-import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 import org.eclipse.emf.ecore.EClass
-import tools.vitruv.dsls.reactions.language.toplevelelements.ReactionsSegment
 import tools.vitruv.dsls.reactions.language.inputTypes.InputTypesPackage
-import tools.vitruv.change.atomic.EChange
 import static extension tools.vitruv.dsls.reactions.codegen.helper.ReactionsLanguageHelper.*;
-import static extension tools.vitruv.dsls.reactions.codegen.helper.ClassNamesGenerators.*;
 import tools.vitruv.dsls.reactions.codegen.helper.AccessibleElement
-import static tools.vitruv.dsls.reactions.codegen.ReactionsLanguageConstants.*;
 import tools.vitruv.dsls.reactions.language.toplevelelements.NamedJavaElementReference
 import tools.vitruv.dsls.common.elements.NamedMetaclassReference
 
@@ -24,18 +19,6 @@ class ParameterGenerator {
 	new (JvmTypeReferenceBuilder typeReferenceBuilder, JvmTypesBuilderWithoutAssociations typesBuilder) {
 		_typeReferenceBuilder = typeReferenceBuilder
 		_typesBuilder = typesBuilder
-	}
-	
-	def JvmFormalParameter generateUntypedChangeParameter(EObject parameterContext) {
-		return parameterContext.generateParameter(new AccessibleElement(CHANGE_PARAMETER_NAME, EChange))
-	}
-	
-	def JvmFormalParameter generateRoutinesFacadeParameter(EObject parameterContext, ReactionsSegment reactionsSegment) {
-		return generateParameter(parameterContext, new AccessibleElement(ROUTINES_FACADE_PARAMETER_NAME, reactionsSegment.routinesFacadeClassNameGenerator.qualifiedName))
-	}
-	
-	def JvmFormalParameter generateReactionExecutionStateParameter(EObject parameterContext) {
-		return generateParameter(parameterContext, new AccessibleElement(REACTION_EXECUTION_STATE_PARAMETER_NAME, ReactionExecutionState))
 	}
 	
 	def generateParameter(EObject contextObject, AccessibleElement element) {


### PR DESCRIPTION
Minor cleanup changes for the Reactions and Commonalities languages.

First, generation of parameters for generated methods in Reactions and routines is made explicit where they are used, i.e., no central constants for names or central generators for specific parameters are used. This results in a common, unified way of generating parameters (passing an `AccessibleElement` to a parameter generator) and in defining the parameter names where the method is defined rather than having a central generator for that. This is reasonable because parameter names must be unique to a method.

Second, unnecessary specifications of implicit call receivers are removed, which have been used for the Commonalities language.
