### PR TITLE
Build framework in validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -8,8 +8,54 @@ jobs:
     name: DSLs
     uses: ./.github/workflows/ci.yml
 
+  build_framework:
+    name: Framework
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Framework
+        uses: actions/checkout@v3
+        with:
+          path: framework
+          repository: vitruv-tools/Vitruv
+          ref: main
+          fetch-depth: 0
+      - name: Checkout Matching Framework Branch
+        run: |
+          cd framework
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Build Framework
+        working-directory: ./framework
+        run: >
+          ./mvnw -B -U clean package
+          -Dstyle.color=always
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+          -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+          -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env:
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Store Framework Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework
+          path: framework/releng/tools.vitruv.updatesite/target/repository
+          retention-days: 1
+
   validate_cbs_applications:
-    needs: validate_dsls
+    needs: [build_framework, validate_dsls]
     name: Application
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +64,11 @@ jobs:
         with:
           name: dsls
           path: dsls
+      - name: Download Framework Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: framework
+          path: framework
       - name: Checkout CBS Applications
         uses: actions/checkout@v3
         with:
@@ -47,6 +98,7 @@ jobs:
           run: >
             ./mvnw -B -U clean verify
             -Dvitruv.dsls.url=file:///${{ github.workspace }}/dsls
+            -Dvitruv.framework.url=file:///${{ github.workspace }}/framework
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/releng/tools.vitruv.dsls.parent/pom.xml
+++ b/releng/tools.vitruv.dsls.parent/pom.xml
@@ -15,7 +15,6 @@
 	<properties>
 		<!-- For each project, a local updatesite can be specified by overwriting these properties. They default to the Vitruv updatesites. -->
 		<vitruv.change.url>https://vitruv-tools.github.io/updatesite/nightly/change/</vitruv.change.url>
-		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
 	</properties>
 
 	<repositories>
@@ -24,11 +23,6 @@
 			<id>Vitruv Change</id>
 			<layout>p2</layout>
 			<url>${vitruv.change.url}</url>
-		</repository>
-		<repository>
-			<id>Vitruv Framework</id>
-			<layout>p2</layout>
-			<url>${vitruv.framework.url}</url>
 		</repository>
 		<repository>
 			<id>Demo Metamodels</id>
@@ -117,18 +111,6 @@
 			</properties>
 		</profile>
 
-		<profile>
-			<id>local-framework</id>
-			<activation>
-				<property>
-					<name>vitruv.framework.path</name>
-				</property>
-			</activation>
-			<properties>
-				<vitruv.framework.url>file:///${vitruv.framework.path}/releng/tools.vitruv.updatesite/target/repository</vitruv.framework.url>
-			</properties>
-		</profile>
-		
 		<profile>
 			<id>dsls-generation</id>
 			<activation>


### PR DESCRIPTION
We yet missed to build the framework in the validation CI. Since the changes repository may already have been changed, we have to build the framework against these changes as well, to then perform the applications validation. We can, however, run that build parallel to the validation of the DSLs, thus it takes no additional build time. We do the same in the Vitruv repository the other way round.