### PR TITLE
V-SUM-independent DSLs tests

### DIFF
--- a/tests/tools.vitruv.dsls.commonalities.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.dsls.commonalities.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-ActivationPolicy: lazy
 Export-Package: tools.vitruv.dsls.commonalities.tests.util,
  tools.vitruv.dsls.commonalities.tests;x-internal=true
 Require-Bundle: tools.vitruv.dsls.commonalities,
- tools.vitruv.testutils.vsum,
+ tools.vitruv.testutils,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
  org.hamcrest.core,

--- a/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/AttributeMappingOperatorExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/AttributeMappingOperatorExecutionTest.xtend
@@ -16,7 +16,6 @@ import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
 import static tools.vitruv.testutils.metamodels.AllElementTypes2Creators.aet2
 import static tools.vitruv.testutils.matchers.ModelMatchers.contains
 import static tools.vitruv.testutils.matchers.ModelMatchers.ignoringFeatures
-import tools.vitruv.testutils.VitruvApplicationTest
 import tools.vitruv.dsls.commonalities.tests.util.TestCommonalitiesGenerator
 import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
 import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes2
@@ -25,7 +24,7 @@ import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFact
 @InjectWith(CommonalitiesLanguageInjectorProvider)
 @TestInstance(PER_CLASS)
 @DisplayName('executing a commonality with attribute mapping operators')
-class AttributeMappingOperatorExecutionTest extends VitruvApplicationTest {
+class AttributeMappingOperatorExecutionTest extends CommonalitiesExecutionTest {
 	@Inject TestCommonalitiesGenerator generator
 	
 	@BeforeAll

--- a/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/CommonalitiesExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/CommonalitiesExecutionTest.xtend
@@ -1,0 +1,31 @@
+package tools.vitruv.dsls.commonalities.tests.execution
+
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.TestLogging
+import org.junit.jupiter.api.^extension.ExtendWith
+import tools.vitruv.testutils.views.TestView
+import org.eclipse.xtend.lib.annotations.Delegate
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import tools.vitruv.testutils.TestProject
+import java.nio.file.Path
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
+import tools.vitruv.change.propagation.ChangePropagationSpecification
+
+@ExtendWith(#[TestLogging, TestProjectManager])
+abstract class CommonalitiesExecutionTest implements TestView {
+	@Delegate var TestView testView
+	
+	protected def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications();
+	
+	@BeforeEach
+	def void prepareTestView(@TestProject Path testProjectPath) {
+		testView = createDefaultChangePublishingTestView(testProjectPath, getChangePropagationSpecifications())
+	}
+
+	@AfterEach
+	def closeTestView() {
+		testView.close()
+	}
+	
+}

--- a/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/IdentifiedExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/IdentifiedExecutionTest.xtend
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import javax.inject.Inject
 import tools.vitruv.testutils.TestProject
 import java.nio.file.Path
-import tools.vitruv.testutils.VitruvApplicationTest
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.BeforeAll
 import org.eclipse.xtend.lib.annotations.Accessors
@@ -35,7 +34,7 @@ import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFact
 @InjectWith(CommonalitiesLanguageInjectorProvider)
 @TestInstance(PER_CLASS)
 @DisplayName('executing simple commonalities')
-class IdentifiedExecutionTest extends VitruvApplicationTest {
+class IdentifiedExecutionTest extends CommonalitiesExecutionTest {
 	@Accessors(PROTECTED_GETTER)
 	@Inject TestCommonalitiesGenerator generator
 	

--- a/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/ReferenceMappingOperatorExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/execution/ReferenceMappingOperatorExecutionTest.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.dsls.commonalities.tests.execution
 
-import tools.vitruv.testutils.VitruvApplicationTest
 import org.junit.jupiter.api.^extension.ExtendWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.eclipse.xtext.testing.InjectWith
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test
 @InjectWith(CommonalitiesLanguageInjectorProvider)
 @TestInstance(PER_CLASS)
 @DisplayName('executing a commonality with attribute mapping operators')
-class ReferenceMappingOperatorExecutionTest extends VitruvApplicationTest {
+class ReferenceMappingOperatorExecutionTest extends CommonalitiesExecutionTest {
 	@Inject TestCommonalitiesGenerator generator
 	
 	@BeforeAll

--- a/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/TestCommonalitiesGenerator.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.tests/src/tools/vitruv/dsls/commonalities/tests/util/TestCommonalitiesGenerator.xtend
@@ -66,7 +66,7 @@ class TestCommonalitiesGenerator {
 		compileGeneratedJava(testProject).forEach[generatedClasses += it]
 	}
 	
-	def Set<? extends ChangePropagationSpecification> createChangePropagationSpecifications() {
+	def Set<ChangePropagationSpecification> createChangePropagationSpecifications() {
 		checkState(!generatedClasses.empty, '''Code must have been generated before creating applications''')
 		return generatedClasses.findAndCombineChangePropagationSpecifications.toSet
 	}

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Automatic-Module-Name: tools.vitruv.dsls.commonalities.ui.tests
 Bundle-ActivationPolicy: lazy
 Require-Bundle: tools.vitruv.dsls.commonalities,
  tools.vitruv.dsls.commonalities.ui,
- tools.vitruv.testutils.vsum,
+ tools.vitruv.testutils,
  tools.vitruv.testutils.metamodels,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.ui.testing,

--- a/tests/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.dsls.reactions.tests/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Export-Package: tools.vitruv.dsls.reactions.builder;x-internal:=true,
  tools.vitruv.dsls.reactions.tests.simpleChangesTests;x-internal:=true
 Automatic-Module-Name: tools.vitruv.dsls.reactions.tests
 Require-Bundle: edu.kit.ipd.sdq.activextendannotations,
- tools.vitruv.testutils.vsum,
+ tools.vitruv.testutils,
  tools.vitruv.testutils.metamodels,
  tools.vitruv.dsls.reactions,
  org.eclipse.xtext.xbase.junit,

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/ReactionsExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/ReactionsExecutionTest.xtend
@@ -15,11 +15,7 @@ import tools.vitruv.testutils.TestLogging
 import tools.vitruv.testutils.views.TestView
 import org.eclipse.xtend.lib.annotations.Delegate
 import org.junit.jupiter.api.BeforeEach
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
-import tools.vitruv.testutils.views.UriMode
-import tools.vitruv.testutils.views.ChangePublishingTestView
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository;
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 import org.junit.jupiter.api.AfterEach
 
 @ExtendWith(InjectionExtension)
@@ -48,13 +44,7 @@ abstract class ReactionsExecutionTest implements TestView {
 
 	@BeforeEach
 	def void prepareTestView(@TestProject Path testProjectPath) {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		testView = new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		testView = createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	@Inject

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/ReactionsExecutionTest.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/ReactionsExecutionTest.xtend
@@ -4,18 +4,31 @@ import com.google.inject.Inject
 import org.eclipse.xtext.testing.InjectWith
 import org.junit.jupiter.api.^extension.ExtendWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension
-import tools.vitruv.testutils.VitruvApplicationTest
 import org.junit.jupiter.api.BeforeAll
 import java.nio.file.Path
 import tools.vitruv.testutils.TestProject
 import org.junit.jupiter.api.TestInstance
 import edu.kit.ipd.sdq.activextendannotations.Lazy
 import static com.google.common.base.Preconditions.checkNotNull
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.TestLogging
+import tools.vitruv.testutils.views.TestView
+import org.eclipse.xtend.lib.annotations.Delegate
+import org.junit.jupiter.api.BeforeEach
+import tools.vitruv.testutils.TestUserInteraction
+import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
+import tools.vitruv.testutils.views.UriMode
+import tools.vitruv.testutils.views.ChangePublishingTestView
+import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository;
+import org.junit.jupiter.api.AfterEach
 
 @ExtendWith(InjectionExtension)
 @InjectWith(ReactionsLanguageInjectorProvider)
 @TestInstance(PER_CLASS)
-abstract class ReactionsExecutionTest extends VitruvApplicationTest {
+@ExtendWith(#[TestLogging, TestProjectManager])
+abstract class ReactionsExecutionTest implements TestView {
+	@Delegate var TestView testView
+
 	Path compilationDir
 	TestReactionsCompiler.Factory factory
 	@Lazy
@@ -33,12 +46,28 @@ abstract class ReactionsExecutionTest extends VitruvApplicationTest {
 		this.compilationDir = compilationDir
 	}
 
+	@BeforeEach
+	def void prepareTestView(@TestProject Path testProjectPath) {
+		val userInteraction = new TestUserInteraction()
+		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
+			changePropagationSpecifications)
+		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
+			userInteraction)
+		testView = new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
+			changeableModelRepository)
+	}
+
 	@Inject
 	def setCompilerFactory(TestReactionsCompiler.Factory factory) {
 		this.factory = factory
 	}
+	
+	@AfterEach
+	def closeTestView() {
+		testView.close()
+	}
 
-	override protected getChangePropagationSpecifications() {
+	def private getChangePropagationSpecifications() {
 		compiler.getChangePropagationSpecifications()
 	}
 }


### PR DESCRIPTION
This PR replaces the `VitruvApplicationTest` base class of reactions and commonalities tests from the V-SUM framework repository with basic `TestViews`, such that the repository becomes independent from the framework repository.