### PR TITLE
Correct CI nightly build schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   release:
     types: [created]
   schedule:
-    - cron: '0 3 30 * *' # run nightly at 3:30 am
+    - cron: '30 3 * * *' # run nightly at 3:30 am
   workflow_call:
 
 jobs:


### PR DESCRIPTION
Corrects the nightly build schedule to run at 3:30AM instead of 3:00AM only on the 30th of the month 😄 

Even though framework and DSLs are independent, I decided to keep the shifted CI schedules such that actions do not fail due to simultaneous commits to the nightly repo.

[POSIX cron syntax](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07)