### PR TITLE
Attempt for making commonalities UI tests stable

### DIFF
--- a/bundles/tools.vitruv.dsls.common.ui/src/tools/vitruv/dsls/common/ui/quickfix/ProjectQuickfix.xtend
+++ b/bundles/tools.vitruv.dsls.common.ui/src/tools/vitruv/dsls/common/ui/quickfix/ProjectQuickfix.xtend
@@ -24,6 +24,9 @@ class ProjectQuickfix {
 			val pluginProject = context.eclipseProject.pluginProject
 			pluginProject.addRequiredBundle(requiredBundle)
 			pluginProject.apply(new NullProgressMonitor)
+			// workaround to fix Windows CI builds as <code>apply</code> does not correctly report its done status.
+			// Detailed problem description: https://github.com/vitruv-tools/Vitruv-DSLs/pull/71
+			Thread.sleep(200)
 		]
 	}
 

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
@@ -47,6 +47,8 @@ class MissingBundlesQuickfixTest extends BugFixedAbstractQuickfixTest {
 				apply(new NullProgressMonitor)
 			]
 		]
+		// workaround to fix Windows CI builds as <code>apply</code> does not correctly report its done status.
+		// Detailed problem description: https://github.com/vitruv-tools/Vitruv-DSLs/pull/71
 		Thread.sleep(200)
 
 		val testCommonality = '''

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
@@ -45,11 +45,11 @@ class MissingBundlesQuickfixTest extends BugFixedAbstractQuickfixTest {
 			pluginProject => [
 				removeRequiredBundle(RUNTIME_BUNDLE)
 				apply(new NullProgressMonitor)
+				// workaround to fix Windows CI builds as <code>apply</code> does not correctly report its done status.
+				// Detailed problem description: https://github.com/vitruv-tools/Vitruv-DSLs/pull/71
+				Thread.sleep(200)
 			]
 		]
-		// workaround to fix Windows CI builds as <code>apply</code> does not correctly report its done status.
-		// Detailed problem description: https://github.com/vitruv-tools/Vitruv-DSLs/pull/71
-		Thread.sleep(200)
 
 		val testCommonality = '''
 			concept test

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/src/tools/vitruv/dsls/commonalities/ui/quickfix/MissingBundlesQuickfixTest.xtend
@@ -47,6 +47,7 @@ class MissingBundlesQuickfixTest extends BugFixedAbstractQuickfixTest {
 				apply(new NullProgressMonitor)
 			]
 		]
+		Thread.sleep(200)
 
 		val testCommonality = '''
 			concept test


### PR DESCRIPTION
Currently, the Windows CI build is failing with high probability in the `MissingBundlesQuickfixTest#fixMissingRuntimeBundle`. The underlying problem here is similar to the problem in https://github.com/vitruv-tools/Vitruv-CaseStudies/pull/220, i.e. the propagation does not wait for the progress monitor to report its done status. Unfortunately, the progress-observed method does not report its done status due to some bug in the implementation. I will report a bug in the Eclipse developer forum on this, but as we can't rely on a quick fix of this, I implemented a workaround which will hopefully resolve the problem.

### Detailed bug description

When calling `apply(new NullProgressMonitor)`, `org.eclipse.pde.internal.core.project.ProjectModifyOperation#execute` is called. In this method, the progress is reported by creating a 6-step submonitor and reporting each subtask progress calling `split(1)` on the subtask monitor. However, for some reason the parent progress monitor (our `NullProgressMonitor` we are passing to the method) only receives 5 calls to `worked(int work)`, resulting in a progress of 833/1000 and thus no call to `done` at all.