### PR TITLE
Migrate to UUIDs

### DIFF
--- a/bundles/tools.vitruv.dsls.testutils/src/tools/vitruv/dsls/testutils/ChangePropagatingTestViewBasedTestModel.java
+++ b/bundles/tools.vitruv.dsls.testutils/src/tools/vitruv/dsls/testutils/ChangePropagatingTestViewBasedTestModel.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
@@ -14,6 +15,7 @@ import com.google.common.collect.FluentIterable;
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil;
 import tools.vitruv.change.composite.description.PropagatedChange;
 import tools.vitruv.testutils.views.NonTransactionalTestView;
+import tools.vitruv.testutils.views.TestView;
 
 /**
  * A {@link TestModel} that propagates performed changes using the functionality
@@ -68,9 +70,10 @@ public class ChangePropagatingTestViewBasedTestModel<T extends EObject> implemen
 	@Override
 	public void applyChanges(Consumer<TestModel<T>> modelModificationFunction,
 			TestViewBasedTestModel<?> otherTestModelToUpdate) {
-		FluentIterable.from(getRootObjects()).forEach(object -> testView.startRecordingChanges(object.eResource()));
+		Set<Resource> resources = getRootObjects().stream().map(it -> it.eResource()).collect(Collectors.toSet());
+		resources.forEach(resource -> testView.startRecordingChanges(resource));
 		modelModificationFunction.accept(this);
-		FluentIterable.from(getRootObjects()).forEach(object -> testView.stopRecordingChanges(object.eResource()));
+		resources.forEach(resource -> testView.stopRecordingChanges(resource));
 		Iterable<PropagatedChange> changes = testView.propagate();
 		FluentIterable.from(changes)
 				.transformAndConcat(change -> change.getConsequentialChanges().getAffectedEObjects())

--- a/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/FamiliesToPersonsTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/FamiliesToPersonsTest.xtend
@@ -23,24 +23,20 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
 import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsHelper
 import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
 import tools.vitruv.testutils.TestLogging
 import tools.vitruv.testutils.TestProject
 import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.testutils.views.ChangePublishingTestView
 import tools.vitruv.testutils.views.TestView
-import tools.vitruv.testutils.views.UriMode
 
 import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
 import static tools.vitruv.testutils.matchers.ModelMatchers.*
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 
 enum MemberRole {
 	Father,
@@ -77,13 +73,7 @@ class FamiliesToPersonsTest implements TestView {
 	}
 
 	private def TestView prepareTestView(Path testProjectPath) throws IOException {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		return new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		return createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	@AfterEach

--- a/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/PersonsToFamiliesTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/PersonsToFamiliesTest.xtend
@@ -21,26 +21,22 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
 import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesHelper
 import tools.vitruv.testutils.TestLogging
 import tools.vitruv.testutils.TestProject
 import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.TestUserInteraction
 import tools.vitruv.testutils.TestUserInteraction.MultipleChoiceInteractionDescription
-import tools.vitruv.testutils.views.ChangePublishingTestView
 import tools.vitruv.testutils.views.TestView
-import tools.vitruv.testutils.views.UriMode
 
 import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
 import static tools.vitruv.testutils.matchers.ModelMatchers.*
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 
 enum PositionPreference {
 	Parent,
@@ -79,13 +75,7 @@ class PersonsToFamiliesTest implements TestView {
 	}
 
 	private def TestView prepareTestView(Path testProjectPath) throws IOException {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		return new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		return createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	@AfterEach

--- a/tests/tools.vitruv.dsls.demo.insurancefamilies.tests/src/tools/vitruv/dsls/demo/insurancefamilies/tests/families2insurance/AbstractFamiliesToInsuranceTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.insurancefamilies.tests/src/tools/vitruv/dsls/demo/insurancefamilies/tests/families2insurance/AbstractFamiliesToInsuranceTest.xtend
@@ -6,14 +6,27 @@ import edu.kit.ipd.sdq.metamodels.insurance.Gender
 import edu.kit.ipd.sdq.metamodels.insurance.InsuranceClient
 import edu.kit.ipd.sdq.metamodels.insurance.InsuranceDatabase
 import edu.kit.ipd.sdq.metamodels.insurance.InsuranceFactory
+import java.io.IOException
 import java.nio.file.Path
 import java.util.ArrayList
 import java.util.List
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.xtend.lib.annotations.Accessors
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.^extension.ExtendWith
+import tools.vitruv.change.propagation.ChangePropagationSpecification
+import tools.vitruv.dsls.demo.insurancefamilies.families2insurance.FamiliesToInsuranceChangePropagationSpecification
+import tools.vitruv.dsls.demo.insurancefamilies.tests.util.InsuranceFamiliesDefaultTestModelFactory
+import tools.vitruv.dsls.demo.insurancefamilies.tests.util.InsuranceFamiliesTestModelFactory
+import tools.vitruv.dsls.testutils.TestModel
+import tools.vitruv.testutils.TestLogging
+import tools.vitruv.testutils.TestProject
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.views.NonTransactionalTestView
 
+import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.dsls.demo.insurancefamilies.tests.util.CreatorsUtil.createFamily
@@ -21,25 +34,9 @@ import static tools.vitruv.dsls.demo.insurancefamilies.tests.util.CreatorsUtil.c
 import static tools.vitruv.dsls.demo.insurancefamilies.tests.util.CreatorsUtil.createInsuranceClient
 import static tools.vitruv.dsls.demo.insurancefamilies.tests.util.FamiliesQueryUtil.claimFamilyRegister
 import static tools.vitruv.dsls.demo.insurancefamilies.tests.util.InsuranceQueryUtil.claimInsuranceDatabase
-import static tools.vitruv.testutils.matchers.ModelMatchers.*
-import org.eclipse.emf.ecore.util.EcoreUtil
-import org.junit.jupiter.api.^extension.ExtendWith
-import tools.vitruv.testutils.TestLogging
-import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.TestProject
-import java.io.IOException
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
-import tools.vitruv.testutils.views.UriMode
-import tools.vitruv.change.propagation.ChangePropagationSpecification
-import static edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI
-import tools.vitruv.testutils.views.NonTransactionalTestView
-import tools.vitruv.dsls.demo.insurancefamilies.tests.util.InsuranceFamiliesDefaultTestModelFactory
-import tools.vitruv.dsls.demo.insurancefamilies.tests.util.InsuranceFamiliesTestModelFactory
-import tools.vitruv.dsls.demo.insurancefamilies.families2insurance.FamiliesToInsuranceChangePropagationSpecification
-import tools.vitruv.testutils.views.ChangePublishingTestView
-import tools.vitruv.dsls.testutils.TestModel
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
+import static tools.vitruv.testutils.matchers.ModelMatchers.containsAllOf
+import static tools.vitruv.testutils.matchers.ModelMatchers.equalsDeeply
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 
 @ExtendWith(#[TestLogging, TestProjectManager])
 abstract class AbstractFamiliesToInsuranceTest {
@@ -60,13 +57,7 @@ abstract class AbstractFamiliesToInsuranceTest {
 	}
 
 	private def NonTransactionalTestView prepareTestView(Path testProjectPath) throws IOException {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		return new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		return createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	protected def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications() {

--- a/tests/tools.vitruv.dsls.demo.insurancepersons.tests/src/tools/vitruv/dsls/demo/insurancepersons/tests/InsuranceToPersonsTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.insurancepersons.tests/src/tools/vitruv/dsls/demo/insurancepersons/tests/InsuranceToPersonsTest.xtend
@@ -1,33 +1,29 @@
 package tools.vitruv.dsls.demo.insurancepersons.tests
 
+import edu.kit.ipd.sdq.metamodels.insurance.Gender
+import edu.kit.ipd.sdq.metamodels.insurance.InsuranceDatabase
+import edu.kit.ipd.sdq.metamodels.insurance.InsuranceFactory
+import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
+import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
+import java.io.IOException
+import java.nio.file.Path
+import org.eclipse.xtend.lib.annotations.Delegate
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.nio.file.Path
+import org.junit.jupiter.api.^extension.ExtendWith
+import tools.vitruv.change.propagation.ChangePropagationSpecification
 import tools.vitruv.dsls.demo.insurancepersons.insurance2persons.InsuranceToPersonsChangePropagationSpecification
-import edu.kit.ipd.sdq.metamodels.insurance.InsuranceFactory
-import edu.kit.ipd.sdq.metamodels.insurance.InsuranceDatabase
-import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
-import edu.kit.ipd.sdq.metamodels.insurance.Gender
-import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
+import tools.vitruv.testutils.TestLogging
+import tools.vitruv.testutils.TestProject
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.views.TestView
 
 import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.testutils.matchers.ModelMatchers.*
-import tools.vitruv.testutils.views.TestView
-import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.TestLogging
-import org.junit.jupiter.api.^extension.ExtendWith
-import org.eclipse.xtend.lib.annotations.Delegate
-import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.testutils.TestProject
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
-import tools.vitruv.testutils.views.ChangePublishingTestView
-import tools.vitruv.testutils.views.UriMode
-import org.junit.jupiter.api.AfterEach
-import java.io.IOException
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 
 @ExtendWith(TestLogging, TestProjectManager)
 class InsuranceToPersonsTest implements TestView {
@@ -50,13 +46,7 @@ class InsuranceToPersonsTest implements TestView {
 	}
 
 	private def TestView prepareTestView(Path testProjectPath) throws IOException {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		return new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		return createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	@AfterEach

--- a/tests/tools.vitruv.dsls.demo.insurancepersons.tests/src/tools/vitruv/dsls/demo/insurancepersons/tests/PersonsToInsuranceTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.insurancepersons.tests/src/tools/vitruv/dsls/demo/insurancepersons/tests/PersonsToInsuranceTest.xtend
@@ -1,33 +1,29 @@
 package tools.vitruv.dsls.demo.insurancepersons.tests
 
-import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
-import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
+import edu.kit.ipd.sdq.metamodels.insurance.Gender
 import edu.kit.ipd.sdq.metamodels.insurance.InsuranceDatabase
 import edu.kit.ipd.sdq.metamodels.insurance.InsuranceFactory
-import edu.kit.ipd.sdq.metamodels.insurance.Gender
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.BeforeEach
+import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
+import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
+import java.io.IOException
 import java.nio.file.Path
+import org.eclipse.xtend.lib.annotations.Delegate
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.^extension.ExtendWith
+import tools.vitruv.change.propagation.ChangePropagationSpecification
 import tools.vitruv.dsls.demo.insurancepersons.persons2insurance.PersonsToInsuranceChangePropagationSpecification
+import tools.vitruv.testutils.TestLogging
+import tools.vitruv.testutils.TestProject
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.views.TestView
 
 import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.testutils.matchers.ModelMatchers.*
-import tools.vitruv.testutils.TestLogging
-import tools.vitruv.testutils.TestProjectManager
-import org.junit.jupiter.api.^extension.ExtendWith
-import tools.vitruv.testutils.views.TestView
-import org.eclipse.xtend.lib.annotations.Delegate
-import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.testutils.TestProject
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
-import tools.vitruv.testutils.views.UriMode
-import tools.vitruv.testutils.views.ChangePublishingTestView
-import org.junit.jupiter.api.AfterEach
-import java.io.IOException
-import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
+import static tools.vitruv.testutils.views.ChangePublishingTestView.createDefaultChangePublishingTestView
 
 @ExtendWith(TestLogging, TestProjectManager)
 class PersonsToInsuranceTest implements TestView {
@@ -50,13 +46,7 @@ class PersonsToInsuranceTest implements TestView {
 	}
 
 	private def TestView prepareTestView(Path testProjectPath) throws IOException {
-		val userInteraction = new TestUserInteraction()
-		val changePropagationSpecificationProvider = new ChangePropagationSpecificationRepository(
-			changePropagationSpecifications)
-		val changeableModelRepository = createTestChangeableModelRepository(changePropagationSpecificationProvider,
-			userInteraction)
-		return new ChangePublishingTestView(testProjectPath, userInteraction, UriMode.FILE_URIS,
-			changeableModelRepository)
+		return createDefaultChangePublishingTestView(testProjectPath, changePropagationSpecifications)
 	}
 
 	@AfterEach


### PR DESCRIPTION
Adapts to API changes introduced by using UUIDs (https://github.com/vitruv-tools/Vitruv-Change/pull/47).