### PR TITLE
Fix Xtend error

### DIFF
--- a/bundles/tools.vitruv.dsls.testutils/src/tools/vitruv/dsls/testutils/InMemoryClassesCompiler.java
+++ b/bundles/tools.vitruv.dsls.testutils/src/tools/vitruv/dsls/testutils/InMemoryClassesCompiler.java
@@ -1,28 +1,25 @@
 package tools.vitruv.dsls.testutils;
 
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.FluentIterable.from;
+import static java.lang.System.lineSeparator;
+import static java.lang.reflect.Modifier.isPublic;
+import static java.nio.file.Files.readString;
+import static java.nio.file.Files.walk;
+import static org.eclipse.xtext.xbase.lib.IterableExtensions.join;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
-import static java.lang.System.lineSeparator;
-import static java.nio.file.Files.readString;
-import org.eclipse.jdt.core.compiler.CategorizedProblem;
-
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static java.nio.file.Files.walk;
-import static com.google.common.collect.FluentIterable.from;
-
+import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.xtext.util.JavaVersion;
 import org.eclipse.xtext.xbase.testing.InMemoryJavaCompiler;
 import org.eclipse.xtext.xbase.testing.InMemoryJavaCompiler.Result;
 import org.eclipse.xtext.xbase.testing.JavaSource;
-import static java.lang.reflect.Modifier.isPublic;
+
 import com.google.common.base.Predicate;
-
-import static org.eclipse.xtext.xbase.lib.IterableExtensions.join;
-
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Allows to compile all Java source files in a given folder at runtime and provides the compiled classes to use
@@ -50,7 +47,7 @@ public class InMemoryClassesCompiler {
 	 */
 	public InMemoryClassesCompiler compile() throws IOException {
 		checkState(compiledClasses == null, "classes have already been compiled");
-		this.compiledClasses = compileJavaFiles(from(walk(javaSourcesFolder).collect(Collectors.toList()))
+		this.compiledClasses = compileJavaFiles(from(walk(javaSourcesFolder).toList())
 				.filter(path -> path.toString().endsWith(".java")).transform(path -> new RelativeAndAbsolutePath(javaSourcesFolder, path)).toList());
 		return this;
 	}

--- a/tests/tools.vitruv.dsls.commonalities.tests/.classpath
+++ b/tests/tools.vitruv.dsls.commonalities.tests/.classpath
@@ -16,6 +16,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/tools.vitruv.dsls.commonalities.ui.tests/.classpath
+++ b/tests/tools.vitruv.dsls.commonalities.ui.tests/.classpath
@@ -16,6 +16,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/tools.vitruv.dsls.demo.familiespersons.tests/.classpath
+++ b/tests/tools.vitruv.dsls.demo.familiespersons.tests/.classpath
@@ -11,6 +11,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/tools.vitruv.dsls.demo.insurancefamilies.tests/.classpath
+++ b/tests/tools.vitruv.dsls.demo.insurancefamilies.tests/.classpath
@@ -11,6 +11,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/tools.vitruv.dsls.demo.insurancepersons.tests/.classpath
+++ b/tests/tools.vitruv.dsls.demo.insurancepersons.tests/.classpath
@@ -5,6 +5,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xtend-gen">

--- a/tests/tools.vitruv.dsls.reactions.tests/.classpath
+++ b/tests/tools.vitruv.dsls.reactions.tests/.classpath
@@ -16,6 +16,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/tests/tools.vitruv.dsls.reactions.ui.tests/.classpath
+++ b/tests/tools.vitruv.dsls.reactions.ui.tests/.classpath
@@ -10,6 +10,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
This PR adds JUnit 5 to all test projects' classpaths, thus fixing the Xtend errors occurring with Xtend 2.29 and Eclipse 2022-12.

https://github.com/vitruv-tools/.github/issues/10

Also refactors stream operations to use the Java 16 `toList()` method.