### PR TITLE
Improve Families-Persons tests

### DIFF
--- a/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/families2persons/FamiliesToPersons.reactions
+++ b/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/families2persons/FamiliesToPersons.reactions
@@ -20,6 +20,9 @@ reaction InsertedFamilyRegister {
 }
 
 routine createPersonRegister(families::FamilyRegister familyRegister) {
+	match {
+		require absence of persons::PersonRegister corresponding to familyRegister
+	}
 	create {
 		val personRegister = new persons::PersonRegister
 	}

--- a/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/persons2families/PersonsToFamilies.reactions
+++ b/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/persons2families/PersonsToFamilies.reactions
@@ -29,6 +29,9 @@ reaction InsertedPersonRegister {
 }
 
 routine createFamilyRegister(persons::PersonRegister createdPersonRegister) {
+	match {
+		require absence of families::FamilyRegister corresponding to createdPersonRegister
+	}
 	create {
 		val newFamilyRegister = new families::FamilyRegister
 	}
@@ -63,6 +66,7 @@ reaction InsertedPerson {
 
 routine insertAsParentOrChild(persons::Person insertedPerson) {
 	match {
+		require absence of families::Member corresponding to insertedPerson 
 		check {
 			assertValidFullname(insertedPerson)
 			true
@@ -191,9 +195,11 @@ routine changeNames(persons::Person renamedPerson, String oldFullname) {
 	}
 	update {
 		// Update firstname
-		correspondingMember.firstName = renamedPerson.firstname
-		// Update lastname and/or role
-		reactToLastnameAndFamilyRoleChanges(renamedPerson, oldFullname)
+		correspondingMember.firstName = renamedPerson.firstname	
+		if (correspondingMember.family.lastName != renamedPerson.lastname) {
+			// Update lastname and potentially role
+			reactToLastnameAndFamilyRoleChanges(renamedPerson, oldFullname)
+		}
 	}
 }
 

--- a/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/persons2families/PersonsToFamilies.reactions
+++ b/bundles/tools.vitruv.dsls.demo.familiespersons/src/tools/vitruv/dsls/demo/familiespersons/persons2families/PersonsToFamilies.reactions
@@ -11,6 +11,7 @@ import static tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToF
 import static extension tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getFirstname
 import static extension tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getLastname
 import static extension tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesHelper.getRegister
+import static extension edu.kit.ipd.sdq.metamodels.families.FamiliesUtil.getFamily
 import static extension edu.kit.ipd.sdq.metamodels.families.FamiliesUtil.getMembers
 
 import "edu.kit.ipd.sdq.metamodels.persons" as persons
@@ -207,44 +208,41 @@ routine reactToLastnameAndFamilyRoleChanges(persons::Person renamedPerson, Strin
 	match {
 		val oldFamily = retrieve families::Family corresponding to renamedPerson
 		val correspondingMember = retrieve families::Member corresponding to renamedPerson
+		val familiesRegister = retrieve families::FamilyRegister corresponding to renamedPerson.register
 	}
 	update {
 		val boolean wasChildBeforeRenaming = correspondingMember.familySon === oldFamily ||
 			correspondingMember.familyDaughter === oldFamily
 		val boolean isSupposedToBeAChild = askUserWhetherPersonIsParentOrChildDuringRenaming(userInteractor,
 			oldFullname, renamedPerson.fullName, wasChildBeforeRenaming) == FamilyRole.Child
-
-		// If neither the lastname, nor the role of the member inside the family changed,
-		// then only the firstname changed and nothing else must be done.
-		if ((wasChildBeforeRenaming !== isSupposedToBeAChild) || (oldFamily.lastName != renamedPerson.lastname)) {
-			if (oldFamily.members.size == 1) {
-				// If the member is alone in its family just rename the oldFamily
-				// and maybe adjust the role of the member which is no problem
-				// since the member is alone.
-				oldFamily.lastName = renamedPerson.lastname
-				// and re-insert member as either child or parent if role is supposed to change
-				if (wasChildBeforeRenaming !== isSupposedToBeAChild) {
-					if (isSupposedToBeAChild) {
-						switch renamedPerson {
-							Male: oldFamily.father = correspondingMember
-							Female: oldFamily.mother = correspondingMember
-						}
-					} else {
-						switch renamedPerson {
-							Male: oldFamily.sons += correspondingMember
-							Female: oldFamily.daughters += correspondingMember
-						}
+			
+		if (oldFamily.members.size == 1 && familiesRegister.families.filter(sameLastname(renamedPerson)).isEmpty) {
+			// If the member is alone in its family just rename the oldFamily
+			// and maybe adjust the role of the member which is no problem
+			// since the member is alone.
+			oldFamily.lastName = renamedPerson.lastname
+			if (wasChildBeforeRenaming !== isSupposedToBeAChild) {
+				if (isSupposedToBeAChild) {
+					switch renamedPerson {
+						Male: oldFamily.sons += correspondingMember
+						Female: oldFamily.daughters += correspondingMember
+					}
+				} else {
+					switch renamedPerson {
+						Male: oldFamily.father = correspondingMember
+						Female: oldFamily.mother = correspondingMember
 					}
 				}
-			} else {
-				// If the member is not alone move it to
-				// a different family depending on lastname and supposed role
-				if (isSupposedToBeAChild) {
-					insertExistingMemberIntoUserChosenFamilyAsChild(renamedPerson)
-				} else {
-					insertExistingMemberIntoUserChosenFamilyAsParent(renamedPerson)
-				}
 			}
+		} else {
+			// If the member is not alone move it to
+			// a different family depending on lastname and supposed role
+			if (isSupposedToBeAChild) {
+				insertExistingMemberIntoUserChosenFamilyAsChild(renamedPerson)
+			} else {
+				insertExistingMemberIntoUserChosenFamilyAsParent(renamedPerson)
+			}
+			deleteFamilyIfEmpty(oldFamily)
 		}
 	}
 }

--- a/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/FamiliesToPersonsTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/FamiliesToPersonsTest.xtend
@@ -9,37 +9,38 @@ import edu.kit.ipd.sdq.metamodels.persons.Male
 import edu.kit.ipd.sdq.metamodels.persons.Person
 import edu.kit.ipd.sdq.metamodels.persons.PersonRegister
 import edu.kit.ipd.sdq.metamodels.persons.PersonsFactory
+import java.io.IOException
 import java.nio.file.Path
 import java.util.stream.Stream
 import org.apache.log4j.Logger
+import org.eclipse.xtend.lib.annotations.Delegate
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
+import org.junit.jupiter.api.^extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import tools.vitruv.change.propagation.ChangePropagationSpecification
+import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
 import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsHelper
+import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
+import tools.vitruv.testutils.TestLogging
+import tools.vitruv.testutils.TestProject
+import tools.vitruv.testutils.TestProjectManager
+import tools.vitruv.testutils.TestUserInteraction
+import tools.vitruv.testutils.views.ChangePublishingTestView
+import tools.vitruv.testutils.views.TestView
+import tools.vitruv.testutils.views.UriMode
 
 import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
-import static tools.vitruv.testutils.matchers.ModelMatchers.*
-import tools.vitruv.testutils.TestProject
-import org.junit.jupiter.api.AfterEach
-import tools.vitruv.testutils.TestProjectManager
-import tools.vitruv.testutils.TestLogging
-import org.junit.jupiter.api.^extension.ExtendWith
-import org.eclipse.xtend.lib.annotations.Delegate
-import tools.vitruv.change.propagation.ChangePropagationSpecificationRepository
-import tools.vitruv.testutils.TestUserInteraction
-import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.testutils.views.TestView
-import tools.vitruv.testutils.views.ChangePublishingTestView
-import tools.vitruv.testutils.views.UriMode
-import java.io.IOException
 import static tools.vitruv.testutils.TestModelRepositoryFactory.createTestChangeableModelRepository
+import static tools.vitruv.testutils.matchers.ModelMatchers.*
 
 enum MemberRole {
 	Father,
@@ -66,7 +67,7 @@ class FamiliesToPersonsTest implements TestView {
 	}
 
 	protected def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications() {
-		return #[new FamiliesToPersonsChangePropagationSpecification()]
+		return #[new FamiliesToPersonsChangePropagationSpecification(), new PersonsToFamiliesChangePropagationSpecification()]
 	}
 
 	@BeforeEach

--- a/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/PersonsToFamiliesTest.xtend
+++ b/tests/tools.vitruv.dsls.demo.familiespersons.tests/src/tools/vitruv/dsls/demo/familiespersons/tests/PersonsToFamiliesTest.xtend
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import tools.vitruv.dsls.demo.familiespersons.families2persons.FamiliesToPersonsChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesChangePropagationSpecification
 import tools.vitruv.dsls.demo.familiespersons.persons2families.PersonsToFamiliesHelper
 import tools.vitruv.testutils.TestUserInteraction.MultipleChoiceInteractionDescription
@@ -68,7 +69,7 @@ class PersonsToFamiliesTest implements TestView {
 	}
 
 	protected def Iterable<ChangePropagationSpecification> getChangePropagationSpecifications() {
-		return #[new PersonsToFamiliesChangePropagationSpecification()]
+		return #[new PersonsToFamiliesChangePropagationSpecification(), new FamiliesToPersonsChangePropagationSpecification()]
 	}
 
 	@BeforeEach


### PR DESCRIPTION
- enable bidirectional change propagation
- add regression test for changing last name and role of family member
- fix changing lsat name and role of family member