### PR TITLE
Rename method to clarify its intent

### DIFF
--- a/bundles/tools.vitruv.dsls.common/src/tools/vitruv/dsls/common/elements/CommonLanguageElementsScopeProvider.xtend
+++ b/bundles/tools.vitruv.dsls.common/src/tools/vitruv/dsls/common/elements/CommonLanguageElementsScopeProvider.xtend
@@ -49,12 +49,12 @@ class CommonLanguageElementsScopeProvider {
 			return createImportsScope(context.eResource)
 		} else if (reference.equals(METACLASS_REFERENCE__METACLASS)) {
 			val potentialMetaclassReference = if(context instanceof MetaclassReference) context
-			return createQualifiedEClassScope(potentialMetaclassReference?.metamodel)
+			return createQualifiedEClassifierScope(potentialMetaclassReference?.metamodel)
 		} else if (reference.equals(METAENUM_REFERENCE__METAMODEL)) {
 			return createImportsScope(context.eResource)
 		} else if (reference.equals(METAENUM_REFERENCE__METAENUM)) {
 			val potentialMetaenumReference = if(context instanceof MetaenumReference) context
-			return createQualifiedEClassScope(potentialMetaenumReference?.metamodel, false, null, EcorePackage.Literals.EENUM)
+			return createQualifiedEClassifierScope(potentialMetaenumReference?.metamodel, false, null, EcorePackage.Literals.EENUM)
 		}
 		return null
 	}
@@ -121,8 +121,8 @@ class CommonLanguageElementsScopeProvider {
 	 * 
 	 * @param metamodelImport - the metamodel to provide all classes of
 	 */
-	def createQualifiedEClassScope(MetamodelImport metamodelImport) {
-		return createQualifiedEClassScope(metamodelImport, false, null, EcorePackage.Literals.EOBJECT);
+	def createQualifiedEClassifierScope(MetamodelImport metamodelImport) {
+		return createQualifiedEClassifierScope(metamodelImport, false, null, EcorePackage.Literals.EOBJECT);
 	}
 
 	/**
@@ -134,7 +134,7 @@ class CommonLanguageElementsScopeProvider {
 	 * @param metamodelImport - the metamodel to provide the classes of
 	 */
 	def createQualifiedEClassScopeWithEObject(MetamodelImport metamodelImport) {
-		return createQualifiedEClassScope(metamodelImport, true, null, EcorePackage.Literals.EOBJECT);
+		return createQualifiedEClassifierScope(metamodelImport, true, null, EcorePackage.Literals.EOBJECT);
 	}
 
 	/**
@@ -145,19 +145,19 @@ class CommonLanguageElementsScopeProvider {
 	 * @param metamodelImport - the metamodel to provide the non-abstract classes of
 	 */
 	def createQualifiedEClassScopeWithoutAbstract(MetamodelImport metamodelImport) {
-		return createQualifiedEClassScope(metamodelImport, false, [if(it instanceof EClass)!abstract
+		return createQualifiedEClassifierScope(metamodelImport, false, [if(it instanceof EClass)!abstract
 			else false
 		], EcorePackage.Literals.EOBJECT);
 	}
 
 	/**
-	 * Create an {@link IScope} that represents all {@link EClasses}s
+	 * Create an {@link IScope} that represents all {@link EClassifier}s
 	 * that are referencable inside the {@link Resource} via {@link Import}s
 	 * by a fully qualified name and have the type of the given {@link #type}.
 	 * 
 	 * @see #createQualifiedEClassifierScope(Resource)
 	 */
-	private def createQualifiedEClassScope(MetamodelImport metamodelImport, boolean includeEObject,
+	private def createQualifiedEClassifierScope(MetamodelImport metamodelImport, boolean includeEObject,
 		Function<EClassifier, Boolean> filter, EClass type) {
 		val classifierDescriptions = if (metamodelImport === null || metamodelImport.package === null) {
 				if (includeEObject) {


### PR DESCRIPTION
Rename the method createQualifiedEClassScope to createQualifiedEClassifierScope to clarify its broader application to EClass and EEnum instances. Also updated the javadoc comment to reflect the changes.
Resolves https://github.com/vitruv-tools/Vitruv-DSLs/pull/80#discussion_r1132528516 as i cannot see the import in the currently available file anymore and resolves https://github.com/vitruv-tools/Vitruv-DSLs/pull/80#discussion_r1132546970.