### PR TITLE
Make `EChange` generic over its content type

### DIFF
--- a/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/AbstractReaction.xtend
+++ b/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/AbstractReaction.xtend
@@ -1,10 +1,11 @@
 package tools.vitruv.dsls.reactions.runtime.reactions
 
-import tools.vitruv.dsls.reactions.runtime.structure.CallHierarchyHaving
-import tools.vitruv.change.atomic.EChange
-import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
-import tools.vitruv.dsls.reactions.runtime.routines.RoutinesFacade
 import java.util.function.Function
+import org.eclipse.emf.ecore.EObject
+import tools.vitruv.change.atomic.EChange
+import tools.vitruv.dsls.reactions.runtime.routines.RoutinesFacade
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.structure.CallHierarchyHaving
 
 /**
  * A Reaction retrieves a routines facade upon each execution and applies the
@@ -18,7 +19,7 @@ abstract class AbstractReaction extends CallHierarchyHaving implements Reaction 
 		this.routinesFacadeGenerator = routinesFacadeGenerator
 	}
 	
-	override execute(EChange change, ReactionExecutionState reactionExecutionState) {
+	override execute(EChange<EObject> change, ReactionExecutionState reactionExecutionState) {
 		val routinesFacade = routinesFacadeGenerator.apply(reactionExecutionState)
 		routinesFacade._pushCaller(this)
 		try {
@@ -28,6 +29,6 @@ abstract class AbstractReaction extends CallHierarchyHaving implements Reaction 
 		}
 	}
 
-	protected def void executeReaction(EChange change, ReactionExecutionState executionState, RoutinesFacade routinesFacade)
+	protected def void executeReaction(EChange<EObject> change, ReactionExecutionState executionState, RoutinesFacade routinesFacade)
 
 }

--- a/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/AbstractReactionsChangePropagationSpecification.xtend
+++ b/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/AbstractReactionsChangePropagationSpecification.xtend
@@ -1,17 +1,19 @@
 package tools.vitruv.dsls.reactions.runtime.reactions
 
-import tools.vitruv.change.composite.MetamodelDescriptor
-import org.apache.log4j.Logger
-import tools.vitruv.change.propagation.impl.AbstractChangePropagationSpecification
 import java.util.List
+import org.apache.log4j.Logger
+import org.eclipse.emf.ecore.EObject
 import tools.vitruv.change.atomic.EChange
-import tools.vitruv.change.interaction.UserInteractor
-import tools.vitruv.change.propagation.ResourceAccess
-import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
-import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView
+import tools.vitruv.change.composite.MetamodelDescriptor
 import tools.vitruv.change.correspondence.Correspondence
-import tools.vitruv.dsls.reactions.runtime.correspondence.ReactionsCorrespondence
+import tools.vitruv.change.correspondence.view.EditableCorrespondenceModelView
+import tools.vitruv.change.interaction.UserInteractor
+import tools.vitruv.change.propagation.ChangePropagationSpecification
+import tools.vitruv.change.propagation.ResourceAccess
+import tools.vitruv.change.propagation.impl.AbstractChangePropagationSpecification
 import tools.vitruv.dsls.reactions.runtime.correspondence.CorrespondenceFactory
+import tools.vitruv.dsls.reactions.runtime.correspondence.ReactionsCorrespondence
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * A {@link ChangePropagationSpecification} that executes {@link Reaction}s.
@@ -31,11 +33,11 @@ abstract class AbstractReactionsChangePropagationSpecification extends AbstractC
 		this.reactions += reaction
 	}
 
-	override doesHandleChange(EChange change, EditableCorrespondenceModelView<Correspondence> correspondenceModel) {
+	override doesHandleChange(EChange<EObject> change, EditableCorrespondenceModelView<Correspondence> correspondenceModel) {
 		return true
 	}
 
-	override propagateChange(EChange change, EditableCorrespondenceModelView<Correspondence> correspondenceModel, ResourceAccess resourceAccess) {
+	override propagateChange(EChange<EObject> change, EditableCorrespondenceModelView<Correspondence> correspondenceModel, ResourceAccess resourceAccess) {
 		LOGGER.trace("Call relevant reactions from " + sourceMetamodelDescriptor + " to " + targetMetamodelDescriptor)
 		for (reaction : reactions) {
 			LOGGER.trace("Calling reaction: " + reaction.class.simpleName + " with change: " + change)

--- a/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/Reaction.xtend
+++ b/bundles/tools.vitruv.dsls.reactions.runtime/src/tools/vitruv/dsls/reactions/runtime/reactions/Reaction.xtend
@@ -1,8 +1,9 @@
 package tools.vitruv.dsls.reactions.runtime.reactions
 
+import org.eclipse.emf.ecore.EObject
 import tools.vitruv.change.atomic.EChange
 import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 interface Reaction {
-	def void execute(EChange change, ReactionExecutionState executionState)
+	def void execute(EChange<EObject> change, ReactionExecutionState executionState)
 }

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/ReactionsLanguageConstants.xtend
@@ -8,6 +8,7 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
 	public static val CALL_BLOCK_FACADE_PARAMETER_NAME = "_routinesFacade"
 	
 	public static val CHANGE_AFFECTED_ELEMENT_ATTRIBUTE = "affectedEObject"
+	public static val CHANGE_AFFECTED_ELEMENT_ACCESSOR = "getAffectedElement()"
 	public static val CHANGE_AFFECTED_FEATURE_ATTRIBUTE = "affectedFeature"
 	public static val CHANGE_OLD_VALUE_ATTRIBUTE = "oldValue"
 	public static val CHANGE_NEW_VALUE_ATTRIBUTE = "newValue"

--- a/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
+++ b/bundles/tools.vitruv.dsls.reactions/src/tools/vitruv/dsls/reactions/codegen/changetyperepresentation/ChangeTypeRepresentationExtractor.xtend
@@ -130,7 +130,7 @@ final class ChangeTypeRepresentationExtractor {
 		val affectedValue = if (elementClass !== null) elementClass.javaClassName else modelElementChange.feature?.feature?.EType?.javaClassName
 		
 		val affectedFeature = modelElementChange.feature?.feature
-		return new ChangeTypeRepresentation(name, clazz.instanceClass, affectedEObject, affectedValue, hasOldValue, hasNewValue, affectedFeature, hasIndex)
+		return new ChangeTypeRepresentation(name, clazz.instanceClass, affectedEObject, affectedValue, hasOldValue, hasNewValue, affectedFeature, hasIndex, #[EObject.canonicalName])
 	}
 	
 	private static def dispatch ChangeTypeRepresentation generateChangeTypeRepresentation(ElementExistenceChangeType modelElementChange, EClass elementClass) {

--- a/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
+++ b/tests/tools.vitruv.dsls.reactions.tests/src/tools/vitruv/dsls/reactions/tests/complexTests/BidirectionalExecutionTests.xtend
@@ -1,24 +1,26 @@
 package tools.vitruv.dsls.reactions.tests.complexTests
 
 import allElementTypes.Root
+import org.eclipse.emf.ecore.EObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import tools.vitruv.change.atomic.eobject.CreateEObject
+import tools.vitruv.change.atomic.eobject.DeleteEObject
+import tools.vitruv.change.atomic.feature.reference.RemoveEReference
+import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference
+import tools.vitruv.change.atomic.root.RemoveRootEObject
 import tools.vitruv.change.composite.description.CompositeContainerChange
 import tools.vitruv.change.composite.description.PropagatedChange
 import tools.vitruv.change.composite.description.VitruviusChange
-import tools.vitruv.change.atomic.eobject.CreateEObject
-import tools.vitruv.change.atomic.feature.reference.ReplaceSingleValuedEReference
-
-import static org.hamcrest.CoreMatchers.*
-import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
-import static tools.vitruv.testutils.matchers.ModelMatchers.*
-import static org.hamcrest.MatcherAssert.assertThat
-import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
-import tools.vitruv.change.atomic.feature.reference.RemoveEReference
-import tools.vitruv.change.atomic.eobject.DeleteEObject
-import tools.vitruv.change.atomic.root.RemoveRootEObject
 import tools.vitruv.dsls.reactions.tests.ReactionsExecutionTest
 import tools.vitruv.dsls.reactions.tests.TestReactionsCompiler
+
+import static org.hamcrest.CoreMatchers.*
+import static org.hamcrest.MatcherAssert.assertThat
+import static tools.vitruv.testutils.matchers.ModelMatchers.*
+import static tools.vitruv.testutils.matchers.ModelMatchers.containsModelOf
+import static tools.vitruv.testutils.metamodels.AllElementTypesCreators.aet
+
 import static extension tools.vitruv.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
 
 class BidirectionalExecutionTests extends ReactionsExecutionTest {
@@ -51,8 +53,8 @@ class BidirectionalExecutionTests extends ReactionsExecutionTest {
 		assertThat(resourceAt(TARGET_MODEL), containsModelOf(resourceAt(SOURCE_MODEL)))
 	}
 
-	private def VitruviusChange getSourceModelChanges(PropagatedChange propagatedChange) {
-		return (propagatedChange.consequentialChanges as CompositeContainerChange).changes.findFirst [
+	private def VitruviusChange<EObject> getSourceModelChanges(PropagatedChange propagatedChange) {
+		return (propagatedChange.consequentialChanges as CompositeContainerChange<EObject>).changes.findFirst [
 			changedURIs.exists [lastSegment == SOURCE_MODEL.toString]
 		]
 	}


### PR DESCRIPTION
Adapts to https://github.com/vitruv-tools/Vitruv-Change/issues/59

There are some `EChanges` like `InsertEReference` that had two type parameters for their affected and new element. These had to be merged to one parameter such that there cannot occur a collision when conforming to the same `EChange<Element>` type. As such, explicit generic type annotations and typecasts had to be added to the code annotation