### PR TITLE
disable SonarQube analysis for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
     name: SonarQube analysis
     runs-on: ubuntu-latest
     needs: [verify]
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: true
 


### PR DESCRIPTION
reason: actions created from dependabot PRs do not have access to secrets