### PR TITLE
refactor p2 dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 target/
 *.log
 .mvn/wrapper/*.jar
+.flattened-pom.xml
+dependency-reduced-pom.xml
 
 # Eclipse
 META-INF

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -79,9 +79,12 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/commonalities/language/pom.xml
+++ b/commonalities/language/pom.xml
@@ -175,14 +175,6 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -205,9 +197,24 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.eclipseutils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/commonalities/runtime.operators/pom.xml
+++ b/commonalities/runtime.operators/pom.xml
@@ -51,9 +51,12 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/commonalities/runtime/pom.xml
+++ b/commonalities/runtime/pom.xml
@@ -93,13 +93,17 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/demo/familiespersons/pom.xml
+++ b/demo/familiespersons/pom.xml
@@ -166,10 +166,6 @@
       <groupId>sdq-demo-metamodels</groupId>
       <artifactId>edu.kit.ipd.sdq.metamodels.persons</artifactId>
     </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -191,6 +187,13 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <!-- p2 compile dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/demo/insurancefamilies/pom.xml
+++ b/demo/insurancefamilies/pom.xml
@@ -174,10 +174,6 @@
       <groupId>sdq-demo-metamodels</groupId>
       <artifactId>edu.kit.ipd.sdq.metamodels.insurance</artifactId>
     </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -200,14 +196,25 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -24,4 +24,59 @@
     <module>sdq-demo-metamodels-wrapper</module>
   </modules>
 
+  <properties>
+    <repo.sdq-demo-metamodels.version>1.9.0</repo.sdq-demo-metamodels.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+        <version>1.9.0</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>sdq-demo-metamodels</id>
+      <name>SDQ Demo Metamodels</name>
+      <url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/${repo.sdq-demo-metamodels.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>sdq-demo-metamodels</groupId>
+        <artifactId>edu.kit.ipd.sdq.metamodels.families</artifactId>
+        <version>1.9.0.202311201524</version>
+      </dependency>
+      <dependency>
+        <groupId>sdq-demo-metamodels</groupId>
+        <artifactId>edu.kit.ipd.sdq.metamodels.persons</artifactId>
+        <version>1.9.0.202311201524</version>
+      </dependency>
+      <dependency>
+        <groupId>sdq-demo-metamodels</groupId>
+        <artifactId>edu.kit.ipd.sdq.metamodels.insurance</artifactId>
+        <version>1.9.0.202311201524</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <pluginRepositories>
+    <!-- required for the p2-layout-resolver plugin -->
+    <pluginRepository>
+      <id>artifactory.openntf.org</id>
+      <name>artifactory.openntf.org</name>
+      <url>https://artifactory.openntf.org/openntf</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
 </project>

--- a/p2wrappers/activextendannotations/pom.xml
+++ b/p2wrappers/activextendannotations/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.dsls.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+
+  <name>p2 Dependency Wrapper Active Xtend Annotations</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.xannotations.version>1.6.0</repo.xannotations.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>xannotations</id>
+      <name>XAnnotations</name>
+      <layout>p2</layout>
+      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>xannotations</groupId>
+      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/eclipseutils/pom.xml
+++ b/p2wrappers/eclipseutils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.dsls.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.dsls.p2wrappers.eclipseutils</artifactId>
+
+  <name>p2 Dependency Wrapper Eclipse Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/emfutils/pom.xml
+++ b/p2wrappers/emfutils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.dsls.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.dsls.p2wrappers.emfutils</artifactId>
+
+  <name>p2 Dependency Wrapper EMF Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/javautils/pom.xml
+++ b/p2wrappers/javautils/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.dsls.p2wrappers</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.dsls.p2wrappers.javautils</artifactId>
+
+  <name>p2 Dependency Wrapper Java Utils</name>
+  <description />
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openntf.maven</groupId>
+        <artifactId>p2-layout-resolver</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sdq-commons</id>
+      <name>SDQ Commons</name>
+      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>sdq-commons</groupId>
+      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
+      <version>2.3.0.202304271319</version>
+      <exclusions>
+        <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/p2wrappers/pom.xml
+++ b/p2wrappers/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>tools.vitruv</groupId>
+    <artifactId>tools.vitruv.dsls</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tools.vitruv.dsls.p2wrappers</artifactId>
+  <packaging>pom</packaging>
+
+  <name>p2 Dependency Wrappers</name>
+  <description />
+
+  <modules>
+    <module>activextendannotations</module>
+    <module>eclipseutils</module>
+    <module>emfutils</module>
+    <module>javautils</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- allow Eclipse updatesites as repositories -->
+        <plugin>
+          <groupId>org.openntf.maven</groupId>
+          <artifactId>p2-layout-resolver</artifactId>
+          <version>1.9.0</version>
+          <extensions>true</extensions>
+        </plugin>
+        <!-- generate empty javadoc JARs for deployment -->
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.2</version>
+          <executions>
+            <execution>
+              <id>javadoc-jar</id>
+              <phase>package</phase>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <configuration>
+                <classifier>javadoc</classifier>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <pluginRepositories>
+    <!-- required for the p2-layout-resolver plugin -->
+    <pluginRepository>
+      <id>artifactory.openntf.org</id>
+      <name>artifactory.openntf.org</name>
+      <url>https://artifactory.openntf.org/openntf</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>tools.vitruv</groupId>
     <artifactId>parent</artifactId>
-    <version>3.0.6</version>
+    <version>3.0.7</version>
   </parent>
 
   <!-- Project Information -->

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
   </modules>
 
   <properties>
+    <vitruv-change.version>3.1.0</vitruv-change.version>
     <!-- Additional Repositories -->
     <repo.emf-compare.version>3.3</repo.emf-compare.version>
     <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
@@ -110,47 +111,47 @@
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.atomic</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.correspondence</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.composite</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.interaction</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.propagation</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.integration</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.core</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.testutils.metamodels</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
       <dependency>
         <groupId>tools.vitruv</groupId>
         <artifactId>tools.vitruv.change.utils</artifactId>
-        <version>3.1.0</version>
+        <version>${vitruv-change.version}</version>
       </dependency>
 
       <!-- external dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -42,67 +42,16 @@
     <module>demo</module>
     <module>reactions</module>
     <module>testutils</module>
+    <module>p2wrappers</module>
   </modules>
 
   <properties>
     <vitruv-change.version>3.1.0</vitruv-change.version>
-    <!-- Additional Repositories -->
-    <repo.emf-compare.version>3.3</repo.emf-compare.version>
-    <repo.sdq-commons.version>2.2.0</repo.sdq-commons.version>
-    <repo.sdq-demo-metamodels.version>1.9.0</repo.sdq-demo-metamodels.version>
-    <repo.xannotations.version>1.6.0</repo.xannotations.version>
     <!-- SonarQube configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
     <sonar.projectKey>vitruv-tools_Vitruv-DSLs</sonar.projectKey>
   </properties>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.openntf.maven</groupId>
-        <artifactId>p2-layout-resolver</artifactId>
-      </plugin>
-    </plugins>
-  </build>
-
-  <repositories>
-    <!-- Maven Central should have priority -->
-    <repository>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <!-- for p2 dependencies, `groupId` specifies the repository -->
-    <repository>
-      <id>emf-compare</id>
-      <name>EMF Compare</name>
-      <layout>p2</layout>
-      <url>https://download.eclipse.org/modeling/emf/compare/updates/releases/${repo.emf-compare.version}</url>
-    </repository>
-    <repository>
-      <id>sdq-commons</id>
-      <name>SDQ Commons</name>
-      <url>https://kit-sdq.github.io/updatesite/release/commons/${repo.sdq-commons.version}</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>sdq-demo-metamodels</id>
-      <name>SDQ Demo Metamodels</name>
-      <url>https://kit-sdq.github.io/updatesite/release/metamodels/demo/${repo.sdq-demo-metamodels.version}</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>xannotations</id>
-      <name>XAnnotations</name>
-      <layout>p2</layout>
-      <url>https://kit-sdq.github.io/updatesite/release/xannotations/${repo.xannotations.version}</url>
-    </repository>
-  </repositories>
 
   <!-- Dependency Management -->
   <dependencyManagement>
@@ -279,62 +228,6 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>5.10.1</version>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-commons</groupId>
-        <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-        <version>2.3.0.202304271319</version>
-        <exclusions>
-          <!-- exclude unnecessary transitive dependencies from sdq-commons p2 repository -->
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>sdq-demo-metamodels</groupId>
-        <artifactId>edu.kit.ipd.sdq.metamodels.families</artifactId>
-        <version>1.9.0.202311201524</version>
-      </dependency>
-      <dependency>
-        <groupId>sdq-demo-metamodels</groupId>
-        <artifactId>edu.kit.ipd.sdq.metamodels.persons</artifactId>
-        <version>1.9.0.202311201524</version>
-      </dependency>
-      <dependency>
-        <groupId>sdq-demo-metamodels</groupId>
-        <artifactId>edu.kit.ipd.sdq.metamodels.insurance</artifactId>
-        <version>1.9.0.202311201524</version>
-      </dependency>
-      <dependency>
-        <groupId>xannotations</groupId>
-        <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-        <version>1.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/reactions/language/pom.xml
+++ b/reactions/language/pom.xml
@@ -151,14 +151,6 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
-    <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
-    </dependency>
 
     <!-- external test dependencies -->
     <dependency>
@@ -186,9 +178,24 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.eclipse</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.javautils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- p2 test dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.eclipseutils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/reactions/runtime/pom.xml
+++ b/reactions/runtime/pom.xml
@@ -101,13 +101,17 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.activextendannotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>xannotations</groupId>
-      <artifactId>edu.kit.ipd.sdq.activextendannotations</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -61,9 +61,12 @@
       <groupId>org.eclipse.xtext</groupId>
       <artifactId>org.eclipse.xtext.xbase.testing</artifactId>
     </dependency>
+
+    <!-- p2 compile dependencies -->
     <dependency>
-      <groupId>sdq-commons</groupId>
-      <artifactId>edu.kit.ipd.sdq.commons.util.emf</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>tools.vitruv.dsls.p2wrappers.emfutils</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
re-package p2 dependencies in wrapper JARs to make them available for users without having to support p2 repositories themselves

depends on the next release of https://github.com/vitruv-tools/Maven-Build-Parent