### PR TITLE
Use snapshot versions of Vitruvius dependencies

### DIFF
--- a/.github/prepare-release
+++ b/.github/prepare-release
@@ -9,13 +9,16 @@ then
     return 1
 fi
 
+vitruv_property_name="vitruv-change.version"
+
 git switch -C prepare-release/$1 || exit 1
 
 set_version_and_commit() {
     ./mvnw versions:set -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
+    ./mvnw versions:set-property -Dproperty=$vitruv_property_name -DnewVersion=$1 -DgenerateBackupPoms=false || return 1
 
     git add pom.xml || return 1
-    git add "**/pom.xml" 2> /dev/null
+    git add "**/pom.xml" 2> /dev/null || return 1
 
     git commit -m "$2" || return 1
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </modules>
 
   <properties>
-    <vitruv-change.version>3.1.2</vitruv-change.version>
+    <vitruv-change.version>3.2.0-SNAPSHOT</vitruv-change.version>
     <!-- SonarQube configuration -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>vitruv-tools</sonar.organization>
@@ -231,4 +231,19 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <repositories>
+    <!-- allow snapshots -->
+    <repository>
+      <id>ossrh-snapshots</id>
+      <name>OSSRH Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Allows us to verify in nightly builds that change in one module don't break internal dependencies. Release version is automatically set in the `prepare-release` script.