### PR TITLE
fix build resources for the Reactions IDE module

### DIFF
--- a/reactions/ide/pom.xml
+++ b/reactions/ide/pom.xml
@@ -37,7 +37,7 @@
         <finalName>${project.artifactId}</finalName>
         <resources>
             <resource>
-                <directory>${project.build.directory}/generated-sources/xtext-java</directory>
+                <directory>${project.basedir}/src-gen/xtext</directory>
             </resource>
         </resources>
         <plugins>


### PR DESCRIPTION
the generated META-INF/services are required for the VSCode extension be able to load EMF resources, including Reactions files