### PR TITLE
separate `reactions:` keywords in Reactions grammar

### DIFF
--- a/reactions/language/src/main/xtend/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
+++ b/reactions/language/src/main/xtend/tools/vitruv/dsls/reactions/formatting2/ReactionsLanguageFormatter.xtend
@@ -52,8 +52,11 @@ class ReactionsLanguageFormatter extends XbaseFormatter {
 	}
 
 	def dispatch void format(ReactionsSegment segment, extension IFormattableDocument document) {
-		segment.regionFor.keyword("reactions:") => [
+		segment.regionFor.keyword("reactions") => [
 			prepend[newLines = 2]
+		]
+		segment.regionFor.keyword(":") => [
+			prepend[noSpace]
 			append[oneSpace]
 		]
 		segment.regionFor.keywordPairs("in", "reaction").forEach [

--- a/reactions/language/src/main/xtext/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
+++ b/reactions/language/src/main/xtext/tools/vitruv/dsls/reactions/ReactionsLanguage.xtext
@@ -15,7 +15,7 @@ MetamodelImport returns common::MetamodelImport:
 	'import' package=[ecore::EPackage|STRING] 'as' name=ValidID (useQualifiedNames?='using' 'qualified' 'names')?;
 
 ReactionsSegment returns toplevelelements::ReactionsSegment:
-	'reactions:' name=ValidID
+	'reactions' ':' name=ValidID
 	'in' 'reaction' 'to' 'changes' 'in' fromMetamodels+=[common::MetamodelImport] ('and'
 	fromMetamodels+=[common::MetamodelImport])*
 	'execute' 'actions' 'in' toMetamodels+=[common::MetamodelImport] ('and' toMetamodels+=[common::MetamodelImport])*

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/AllElementTypesRedundancy.reactions
@@ -1,5 +1,5 @@
-import tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
+import tools.vitruv.dsls.^reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
 import org.eclipse.emf.ecore.change.FeatureChange
 import tools.vitruv.change.atomic.^root.RootEChange
 import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/CommonRoutines.reactions
@@ -1,5 +1,5 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Direct2SN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Direct2SN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/DirectRoutinesQN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/DirectRoutinesQN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/DirectSN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/DirectSN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Root.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Root.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Transitive2SN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Transitive2SN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Transitive3SN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/Transitive3SN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesQN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesQN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveRoutinesSN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions
+++ b/reactions/language/src/test/resources/tools/vitruv/dsls/reactions/tests/importTests/TransitiveSN.reactions
@@ -1,7 +1,7 @@
-import tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTests.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
-import static tools.vitruv.dsls.reactions.tests.importTests.ImportTestsUtils.*
+import tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTests.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsExecutionMonitor.ExecutionType.*
+import static tools.vitruv.dsls.^reactions.tests.importTests.ImportTestsUtils.*
 
 import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as minimal
 

--- a/reactions/language/src/test/xtend/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
+++ b/reactions/language/src/test/xtend/tools/vitruv/dsls/reactions/builder/FluentReactionsLanguageBuilderTests.xtend
@@ -24,7 +24,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			]
 
 		val reactionResult = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -63,7 +63,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			]
 
 		val reactionResult = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -122,7 +122,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		builder += extendedSegment
 
 		val reactionResult = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -206,7 +206,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		builder += extendedSegment
 
 		val reactionResult = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -295,7 +295,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		builder += extendedSegment2
 
 		val reactionResult = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -387,7 +387,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 			]
 
 		val expectedReaction = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -425,7 +425,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		reactionsFile += reactionsSegment
 
 		val expectedReaction = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			import "http://www.eclipse.org/emf/2002/Ecore" as ecore
@@ -480,7 +480,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		reactionsFile += reactionsSegment
 
 		val expectedReaction = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
@@ -585,7 +585,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 
 		val expectedReaction = '''
 			import «objectExtensionsFqn»
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			
@@ -639,7 +639,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 				create.reaction('CreateRoot2Test').afterElement(Root2).created.call(commonRoutine)
 
 		val expectedReaction = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			import "http://www.eclipse.org/emf/2002/Ecore" as ecore
@@ -705,7 +705,7 @@ class FluentReactionsLanguageBuilderTests extends FluentReactionsBuilderTest {
 		reactionsFile += secondSegment
 
 		val expectedReaction = '''
-			import tools.vitruv.dsls.reactions.runtime.^routines.AbstractRoutine.Update
+			import tools.vitruv.dsls.^reactions.runtime.^routines.AbstractRoutine.Update
 			
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes" as allElementTypes
 			import "http://tools.vitruv.change.testutils.metamodels.allElementTypes2" as allElementTypes2

--- a/reactions/language/src/test/xtend/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
+++ b/reactions/language/src/test/xtend/tools/vitruv/dsls/reactions/formatting2/ReactionLanguageFormatterTest.xtend
@@ -61,7 +61,7 @@ class ReactionLanguageFormatterTest {
 	@Test
 	def void testAllStatementTypes() {
 		val expected = '''
-		import static tools.vitruv.dsls.reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
+		import static tools.vitruv.dsls.^reactions.tests.simpleChangesTests.SimpleChangesTestsExecutionMonitor.ChangeType.*;
 		import tools.vitruv.change.atomic.eobject.EObjectExistenceEChange
 		import static extension tools.vitruv.change.testutils.metamodels.TestMetamodelsPathFactory.allElementTypes
 		

--- a/reactions/vscode-plugin/src/lsp/reactionslanguage.tmLanguage.json
+++ b/reactions/vscode-plugin/src/lsp/reactionslanguage.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "patterns": [
     {
-      "match": "\\b(absence|actions|after|and|anychange|as|asserted|at|attribute|call|case|catch|changes|check|corresponding|create|created|default|deleted|do|element|else|execute|extends|extension|false|finally|for|from|if|import|in|inserted|instanceof|many|match|names|new|null|of|optional|plain|qualified|reaction|removed|replaced|require|retrieve|return|root|routine|routines|static|super|switch|synchronized|tagged|throw|to|true|try|typeof|update|using|val|var|while|with)\\b",
+      "match": "\\b(absence|actions|after|and|anychange|as|asserted|at|attribute|call|case|catch|changes|check|corresponding|create|created|default|deleted|do|element|else|execute|extends|extension|false|finally|for|from|if|import|in|inserted|instanceof|many|match|names|new|null|of|optional|plain|qualified|reaction|reactions|removed|replaced|require|retrieve|return|root|routine|routines|static|super|switch|synchronized|tagged|throw|to|true|try|typeof|update|using|val|var|while|with)\\b",
       "name": "keyword.control.reactionslanguage"
     },
     {


### PR DESCRIPTION
- requires changes to the formatter
- breaking, as `reactions` is now a keyword and needs to be escaped, e.g., in URIs, see https://github.com/vitruv-tools/Vitruv-CaseStudies/pull/349
- fixes missing keyword highlight of `reactions` in VSCode:

<img width="1238" height="676" alt="image" src="https://github.com/user-attachments/assets/fc95e764-97f9-49d4-8b2a-7fd0d4b0a02c" />
