### PR TITLE
Update JUnit to Version 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,12 +226,12 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.12.0</version>
+        <version>6.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.12.0</version>
+        <version>6.0.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Updates the JUnit API and Platform to Version 6.

Works (on my machine, and others :-)) after applying Pull Request 322 in Vitruv-Change. Updating JUnit to Version 6 fixes problems with `FeatureMappingReferencingTest`.