### PR TITLE
Local builds and additional jars within the VS Code extension

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+mvnw     text eol=lf
+mvnw.cmd text eol=crlf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
 
     - name: Package extension
       working-directory: reactions/vscode-plugin
-      run: npx @vscode/vsce package
+      env:
+        REACTIONS_SKIP_LSP_JAR_BUILD: "true"
+      run: npx --yes @vscode/vsce@3.9.1 package
 
     - name: Stage build results
       run: mkdir staging-${{ matrix.os }} && cp reactions/vscode-plugin/*.vsix staging-${{ matrix.os }}/;

--- a/reactions/ide/pom.xml
+++ b/reactions/ide/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -60,10 +60,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.eclipse.xtend</groupId>
                 <artifactId>xtend-maven-plugin</artifactId>
             </plugin>
@@ -74,7 +70,7 @@
                     <transformers>
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>org.eclipse.xtext.ide.server.ServerLauncher</mainClass>
+                            <mainClass>tools.vitruv.dsls.reactions.ide.ReactionsServerLauncher</mainClass>
                         </transformer>
                         <transformer
                                 implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/BuildOutputSkippingFileSystemScanner.xtend
+++ b/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/BuildOutputSkippingFileSystemScanner.xtend
@@ -1,0 +1,34 @@
+package tools.vitruv.dsls.reactions.ide
+
+import com.google.inject.Singleton
+import java.io.File
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.util.IAcceptor
+import org.eclipse.xtext.util.IFileSystemScanner
+
+ /**
+  * File system scanner that skips build outputs for different ides. This is required, so only a unique file within {@code src/main/reactions/} and {@code target/classes/} is indexed by the LSP, to prevent duplicate type errors.
+  */
+@Singleton
+class BuildOutputSkippingFileSystemScanner extends IFileSystemScanner.JavaIoFileSystemScanner {
+	static val SKIPPED_DIRECTORIES = #{
+		"target",
+		"build",
+		"bin",
+		"out",
+		"node_modules",
+		".git",
+		".gradle",
+		".idea",
+		".vscode",
+		".settings"
+	}
+
+	override scanRec(File file, IAcceptor<URI> acceptor) {
+		if (file.directory && SKIPPED_DIRECTORIES.contains(file.name)) {
+			return
+		}
+
+		super.scanRec(file, acceptor)
+	}
+}

--- a/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/ReactionsLanguageIdeSetup.xtend
+++ b/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/ReactionsLanguageIdeSetup.xtend
@@ -4,7 +4,12 @@
 package tools.vitruv.dsls.reactions.ide
 
 import com.google.inject.Guice
+import java.net.URL
+import javax.xml.parsers.DocumentBuilderFactory
+import org.apache.logging.log4j.LogManager
+import org.eclipse.emf.ecore.EPackage
 import org.eclipse.xtext.util.Modules2
+import org.w3c.dom.Element
 import tools.vitruv.dsls.reactions.ReactionsLanguageRuntimeModule
 import tools.vitruv.dsls.reactions.ReactionsLanguageStandaloneSetup
 
@@ -12,9 +17,77 @@ import tools.vitruv.dsls.reactions.ReactionsLanguageStandaloneSetup
  * Initialization support for running Xtext languages as language servers.
  */
 class ReactionsLanguageIdeSetup extends ReactionsLanguageStandaloneSetup {
+	static val LOG = LogManager.getLogger(ReactionsLanguageIdeSetup)
 
 	override createInjector() {
 		Guice.createInjector(Modules2.mixin(new ReactionsLanguageRuntimeModule, new ReactionsLanguageIdeModule))
 	}
-	
+
+	override createInjectorAndDoEMFRegistration() {
+		registerMetamodelsFromPluginXml()
+		super.createInjectorAndDoEMFRegistration()
+	}
+
+	/**
+	 * Registers every package declared in any plugin.xml on the classpath.
+	 * This covers all additional paths supplied through the extension settings.
+	 */
+	def private static void registerMetamodelsFromPluginXml() {
+		val classLoader = ReactionsLanguageIdeSetup.classLoader
+		try {
+			val resources = classLoader.getResources("plugin.xml")
+			var registered = 0
+			while (resources.hasMoreElements) {
+				registered += registerPackagesFromPluginXml(resources.nextElement, classLoader)
+			}
+
+			LOG.info('''Registered «registered» EPackages from plugin.xml files on the classpath.''')
+		} catch (Throwable t) {
+			LOG.error("Failed to scan plugin.xml for metamodels.", t)
+		}
+	}
+
+	/**
+	 * Parses a single {@code plugin.xml} and registers all of its package declarations.
+	 * Returns the number of newly registered EPackages.
+	 */
+	def private static int registerPackagesFromPluginXml(URL url, ClassLoader classLoader) {
+		try (val stream = url.openStream) {
+			val factory = DocumentBuilderFactory.newInstance() => [
+				namespaceAware = false
+			]
+
+			val nodes = factory.newDocumentBuilder().parse(stream).getElementsByTagName("package")
+			var registered = 0
+			for (var i = 0; i < nodes.length; i++) {
+				if (registerPackage(nodes.item(i) as Element, classLoader)) {
+					registered++
+				}
+			}
+
+			return registered
+		} catch (Throwable t) {
+			LOG.debug('''Failed to process «url»: «t.message»''')
+			return 0
+		}
+	}
+
+	def private static boolean registerPackage(Element node, ClassLoader classLoader) {
+		val uri = node.getAttribute("uri")
+		val className = node.getAttribute("class")
+		if (uri.nullOrEmpty || className.nullOrEmpty || EPackage.Registry.INSTANCE.containsKey(uri)) {
+			return false
+		}
+
+		try {
+			val cls = Class.forName(className, true, classLoader)
+			val pkg = cls.getField("eINSTANCE").get(null) as EPackage
+			EPackage.Registry.INSTANCE.put(uri, pkg)
+			return true
+		} catch (Throwable t) {
+			LOG.debug('''Skipping «uri» («className»): «t.message»''')
+			return false
+		}
+	}
+
 }

--- a/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/ReactionsServerLauncher.xtend
+++ b/reactions/ide/src/main/xtend/tools/vitruv/dsls/reactions/ide/ReactionsServerLauncher.xtend
@@ -1,0 +1,19 @@
+package tools.vitruv.dsls.reactions.ide
+
+import com.google.inject.AbstractModule
+import com.google.inject.util.Modules
+import org.eclipse.xtext.ide.server.ServerLauncher
+import org.eclipse.xtext.ide.server.ServerModule
+import org.eclipse.xtext.util.IFileSystemScanner
+
+class ReactionsServerLauncher {
+	def static void main(String[] args) {
+		val overridden = Modules.override(new ServerModule()).with(new AbstractModule() {
+			override configure() {
+				bind(IFileSystemScanner).to(BuildOutputSkippingFileSystemScanner)
+			}
+		})
+
+		ServerLauncher.launch("Reactions LSP", args, overridden)
+	}
+}

--- a/reactions/vscode-plugin/esbuild.cjs
+++ b/reactions/vscode-plugin/esbuild.cjs
@@ -1,9 +1,52 @@
 const esbuild = require("esbuild");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 
 const isProduction = process.argv.includes("--production");
 const isWatch = process.argv.includes("--watch");
 
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const JAR_NAME = "tools.vitruv.dsls.reactions.ide.jar";
+const JAR_SRC = path.join(REPO_ROOT, "reactions", "ide", "target", JAR_NAME);
+const JAR_DEST = path.join(__dirname, JAR_NAME);
+
+function buildAndCopyLspJar() {
+	if (process.env.REACTIONS_SKIP_LSP_JAR_BUILD === "true") {
+		if (!fs.existsSync(JAR_DEST)) {
+			throw new Error(
+				`REACTIONS_SKIP_LSP_JAR_BUILD is set but ${JAR_NAME} is missing at ${JAR_DEST}. ` +
+				`Maybe the CI did not built it successfully.`
+			);
+		}
+
+		console.log("[lsp-jar] Skipping Maven build");
+		return;
+	}
+
+	const mvn = path.join(REPO_ROOT, process.platform === "win32" ? "mvnw.cmd" : "mvnw");
+	console.log(`[lsp-jar] Building ${JAR_NAME} via Maven...`);
+	const result = spawnSync(
+		mvn,
+		["-pl", "reactions/ide", "-am", "package", "-DskipTests", "-q"],
+		{ cwd: REPO_ROOT, stdio: "inherit", shell: true }
+	);
+
+	if (result.status !== 0) {
+		throw new Error(`Maven build failed with exit code ${result.status}`);
+	}
+
+	if (!fs.existsSync(JAR_SRC)) {
+		throw new Error(`Expected JAR not found at ${JAR_SRC}`);
+	}
+
+	fs.copyFileSync(JAR_SRC, JAR_DEST);
+	console.log(`[lsp-jar] Copied to ${path.relative(REPO_ROOT, JAR_DEST)}`);
+}
+
 async function main() {
+	buildAndCopyLspJar();
+
 	const ctx = await esbuild.context({
 		entryPoints: ["src/extension.ts"],
 		bundle: true,

--- a/reactions/vscode-plugin/package.json
+++ b/reactions/vscode-plugin/package.json
@@ -4,7 +4,7 @@
 	"description": "Reactions VSCode Extension",
 	"author": "",
 	"license": "EPL-1.0",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vitruv-tools/Vitruv-DSLs"
@@ -35,7 +35,18 @@
 				"scopeName": "source.reactionslanguage",
 				"path": "./src/lsp/reactionslanguage.tmLanguage.json"
 			}
-		]
+		],
+		"configuration": {
+			"title": "Reactions",
+			"properties": {
+				"reactions.metamodelJars": {
+					"type": "array",
+					"items": { "type": "string" },
+					"default": [],
+					"markdownDescription": "Absolute paths to metamodel jars to load into the Reactions language server classpath. Each jar's `plugin.xml` is auto-registered via `EcorePlugin.ExtensionProcessor`."
+				}
+			}
+		}
 	},
 	"files": [
 		"package.json",

--- a/reactions/vscode-plugin/src/lsp/index.ts
+++ b/reactions/vscode-plugin/src/lsp/index.ts
@@ -3,24 +3,37 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as path from "path";
+import * as path from "node:path";
 
-import { ExtensionContext } from "vscode";
+import { ExtensionContext, workspace } from "vscode";
 import {
-	Executable,
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
 	TransportKind,
 } from "vscode-languageclient/node";
 
+const LSP_JAR = "tools.vitruv.dsls.reactions.ide.jar";
+const LSP_MAIN_CLASS = "tools.vitruv.dsls.reactions.ide.ReactionsServerLauncher";
+
+function buildJavaArgs(metamodelJars: string[]): string[] {
+	if (metamodelJars.length === 0) {
+		return ["-jar", LSP_JAR, "-log", "-trace"];
+	}
+
+	const classpaths = [LSP_JAR, ...metamodelJars].join(path.delimiter);
+	return ["-cp", classpaths, LSP_MAIN_CLASS, "-log", "-trace"];
+}
+
 export async function activate(context: ExtensionContext) {
+	const additionalJars = workspace
+		.getConfiguration("reactions")
+		.get<string[]>("metamodelJars", []);
+
 	const xtextServerOptions: ServerOptions = {
 		command: "java",
 		transport: TransportKind.stdio,
-		args: [
-			"-jar", "tools.vitruv.dsls.reactions.ide.jar","-log",'-trace'
-		],
+		args: buildJavaArgs(additionalJars),
 		options: {
 			cwd: context.extensionPath,
 		},
@@ -38,7 +51,6 @@ export async function activate(context: ExtensionContext) {
 	);
 
 	await client.start();
-
 	context.subscriptions.push(client);
 
 	return client;


### PR DESCRIPTION
When building the extension locally before, the lsp jar was not copied over and was missing from the .vsix file, so loading it up, only showed minor syntax highlighting, but no real errors. It worked when built over the pipeline, but the copy step was missing locally, so now developers have the chance to test the extension before merging and letting the workflow run.

You can now also add paths to additional jars, which the extension should respect. Before you still had some squiggly lines, as most of the imported stuff could not get found. With that, you add an additional path, reload VS Code, so the initialization fires again and the corresponding errors can disappear. This can be done within the settings for the extension, to make development of reactions easier.